### PR TITLE
Wink Modularization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# homebridge-wink
+[Homebridge](https://github.com/nfarina/homebridge) platform plugin for the Wink hub
+
+This repository contains the Wink plugin for homebridge that was previously bundled in the main `homebridge` repository.
+
+# Installation
+
+
+1. Install homebridge using: npm install -g homebridge
+2. Install this plugin using: npm install -g homebridge-wink
+3. Update your configuration file. See sample-config.json snippet below. 
+
+# Configuration
+
+Configuration sample:
+
+ ```
+"platforms": [
+		{
+			"platform": "Wink",
+			"name": "Wink",
+			"client_id": "YOUR_WINK_API_CLIENT_ID",
+			"client_secret": "YOUR_WINK_API_CLIENT_SECRET",
+			"username": "your@email.com",
+			"password": "WINK_PASSWORD"
+		}
+	],
+
+```
+
+Fields: 
+
+* "platform": Must always be "Nest" (required)
+* "name": Can be anything (required)
+* "client_id": Wink API client id, must be obtained from questions@quirky.com (required)
+* "client_secret": Wink API client id, must be obtained from questions@quirky.com (required)
+* "username": Wink login username, same as app (required)
+* "password": Wink login password, same as app (required)
+

--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@ This repository contains the Wink plugin for homebridge that was previously bund
 
 # Installation
 
-
-1. Install homebridge using: npm install -g homebridge
-2. Install this plugin using: npm install -g homebridge-wink
-3. Update your configuration file. See sample-config.json snippet below. 
+Instructions Coming Soon.
 
 # Configuration
 
@@ -22,7 +19,10 @@ Configuration sample:
 			"client_id": "YOUR_WINK_API_CLIENT_ID",
 			"client_secret": "YOUR_WINK_API_CLIENT_SECRET",
 			"username": "your@email.com",
-			"password": "WINK_PASSWORD"
+			"password": "WINK_PASSWORD",
+        	"hide_groups": ["garage_doors", "thermostats"],
+        	"hide_ids": []
+			
 		}
 	],
 
@@ -30,10 +30,75 @@ Configuration sample:
 
 Fields: 
 
-* "platform": Must always be "Nest" (required)
+* "platform": Must always be "Wink" (required)
 * "name": Can be anything (required)
 * "client_id": Wink API client id, must be obtained from questions@quirky.com (required)
 * "client_secret": Wink API client id, must be obtained from questions@quirky.com (required)
 * "username": Wink login username, same as app (required)
 * "password": Wink login password, same as app (required)
+* "hide_groups": List of Wink groups that will be hidden from Homebridge. Accepted values are:  
+  * air_contidioners  
+  * binary_switches  
+  * garage_doors  
+  * light_bulbs  
+  * locks  
+  * outlets  
+  * sensor_pods  
+  * smoke_detectors  
+  * thermostats
+* "hide_ids": List of Wink IDs that will be hidden from Homebrige. These ID can easily be seen in the initialization portion of homebridge.
+* "temperature_unit" : Identifies the display unit for thermostats. F or C. Defaults to F
+* "unregister_disconnected" : Blocks devices that are currently disconnected from the Wink hub. true/false. Defaults to true.
 
+# Device Support
+
+Supported Devices:
+
+* Air Conditioners - Identifies the direct-connected Wink Aros. 
+  * Change between cool, auto and off.
+  * Set temperature.
+  * Direct fan control is not yet available.
+* Binary Switches - Z-Wave non-dimming switches, Wink Outlink, Wink Relay.
+  * On/Off Functions.
+  * For the Outlink, uses the power usage to determine if on or off.
+  * Does not report actual power usage due to limitation in HomeKit Interface.
+* Garage Doors
+  * Open/Close Wink-connected garage doors.
+  * Report battery status to HomeKit.
+  * Does not identify blocked doors due to limitation in Wink Interface.
+* Light Bulbs - Light Bulbs and dimmable switches.
+  * On/Off and Dimming.
+  * Bulbs with support allow Hue and Saturation.
+* Locks
+  * Lock/Unlock and report current status.
+  * Report Battery Status.
+  * Does not support tampering due to limitation in developer's locks and possibly Wink API.
+* Outlets - The controllable outlets on the Quirky Power Strip.
+  * On/Off
+  * Does not group the outlets by power strip due to limitation in HomeKit Interface.
+* Sensor Pods - Spotter, Tripper and other PIR and Door Sensors.
+  * PIR reports as Motion Detector
+  * Tripper and other Door Sensors report as Doors. Tamper Detection is not available in HomeKit for these.
+  * Spotter reports Temperature and Humidity to HomeKit.
+  * Spotter Reports Battery Level.
+  * Spotter does not report brightness, vibration or loudness to HomeKit. Apple expects values and these are simply reported as yes/no concerning if it changed.
+* Smoke Detectors - I believe only Kiddie detectors are supported
+  * Reports Battery Level.
+  * Reports CO and Smoke Alarms as available by the detector
+* Thermostats
+  * Should be full functionality.
+  
+Not Yet Supported Devices In Consideration
+
+* Cameras
+
+Not Supported Due to HomeKit Limitations
+
+* Eggtrays - No compatible device in HomeKit
+* Piggy Banks - No compatible device in HomeKit
+* Hubs - Redundant the way homebridge platform plugins are designed
+* Remotes - Only displays what it is linked to and doesn't allow as remote
+* Buttons - The TAPT and Wink Relay buttons. I expect these are too time-delayed to be useful.
+* "Unknown Devices" - Wink doesn't even know what these are.
+
+If you disagree with any of my "limitations in HomeKit", feel free to create and issue for a feature request that reveals what I'm missing.

--- a/accessories/air_conditioners.js
+++ b/accessories/air_conditioners.js
@@ -1,0 +1,173 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Air Conditioner Accessory
+ */
+
+function WinkAirConditionerAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'air_conditioners';
+    this.deviceId = this.device.air_conditioner_id;
+
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
+
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
+
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
+    this
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name);
+
+    //Items specific to Thermostats:
+
+    //Handle the Current State
+    this
+        .addService(Service.Thermostat)
+        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+        .on('get', function(callback) {
+            if (that.device.last_reading.powered) { //I need to verify this changes when the thermostat clicks on.
+                switch (that.device.last_reading.mode) {
+                    case "cool_only":
+                        callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+                        break;
+                    case "auto_eco": //HomeKit only accepts HEAT/COOL, so we have to determine if we are Heating or Cooling.
+                        if (that.device.last_reading.temperature > that.device.last_reading.max_set_point)
+                            callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+                        else
+                            callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+                        break;
+                    default: //If it is fan_only or anything else then we'll report the thermostat as off.
+                        callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+                        break;
+                }
+            } else //For now, powered being false means it is off
+                callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+        });
+
+    //Handle the Target State
+    //Handle the Current State
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+        .on('get', function(callback) {
+            if (that.device.desired_state.powered) { //I need to verify this changes when the thermostat clicks on.
+                switch (that.device.desired_state.mode) {
+                    case "cool_only":
+                        callback(null, Characteristic.TargetHeatingCoolingState.COOL);
+                        break;
+                    case "auto_eco":
+                        callback(null, Characteristic.TargetHeatingCoolingState.AUTO);
+                        break;
+                    default: //The above list should be inclusive, but we need to return something if they change stuff.
+                        callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+                        break;
+                }
+            } else //For now, powered being false means it is off
+                callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+        })
+        .on('set', function(value, callback) {
+            switch (value) {
+                case Characteristic.TargetHeatingCoolingState.COOL:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, ["powered", "mode"], [true, "cool_only"]);
+                    break;
+                case Characteristic.TargetHeatingCoolingState.AUTO:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, ["powered", "mode"], [true, "auto_eco"]);
+                    break;
+                case Characteristic.TargetHeatingCoolingState.OFF:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, "powered", false);
+                    break;
+            }
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.CurrentTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.temperature);
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.TargetTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.desired_state.max_set_point);
+        })
+        .on('set', function(value, callback) {
+            platform.UpdateWinkProperty_noFeedback(that, callback, "max_set_point", value);
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+        .on('get', function(callback) {
+            if (platform.temperature_unit == "C")
+                callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+            else
+                callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
+        });
+
+}
+
+WinkAirConditionerAccessory.prototype = {
+    loadData: function() {
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.CurrentTemperature)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.TargetTemperature)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+            .getValue();
+
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
+    }
+}
+module.exports = WinkAirConditionerAccessory;

--- a/accessories/air_conditioners.js
+++ b/accessories/air_conditioners.js
@@ -54,8 +54,6 @@ function WinkAirConditionerAccessory(platform, device) {
 				callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
 		});
 
-	//Handle the Target State
-	//Handle the Current State
 	this
 		.getService(Service.Thermostat)
 		.getCharacteristic(Characteristic.TargetHeatingCoolingState)
@@ -116,6 +114,16 @@ function WinkAirConditionerAccessory(platform, device) {
 				callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
 		});
 
+	this
+		.getService(Service.Thermostat)
+		.addCharacteristic(Characteristic.RotationSpeed)
+		.on('get', function (callback) {
+			callback(null, Math.floor(that.device.last_reading.fan_speed * 100));
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, "fan_speed", value / 100);
+		});
+
 	this.loadData();
 }
 
@@ -143,6 +151,11 @@ var loadData = function () {
 	this
 		.getService(Service.Thermostat)
 		.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+		.getValue();
+
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.RotationSpeed)
 		.getValue();
 
 };

--- a/accessories/air_conditioners.js
+++ b/accessories/air_conditioners.js
@@ -7,143 +7,142 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Air Conditioner Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkAirConditionerAccessory, WinkAccessory);
-        WinkAirConditionerAccessory.prototype.loadData = loadData;
-        WinkAirConditionerAccessory.prototype.deviceGroup = 'air_conditioners';
-    }
-    return WinkAirConditionerAccessory;
+		inherits(WinkAirConditionerAccessory, WinkAccessory);
+		WinkAirConditionerAccessory.prototype.loadData = loadData;
+		WinkAirConditionerAccessory.prototype.deviceGroup = 'air_conditioners';
+	}
+	return WinkAirConditionerAccessory;
 };
 module.exports.WinkAirConditionerAccessory = WinkAirConditionerAccessory;
 
 function WinkAirConditionerAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.air_conditioner_id);
+	WinkAccessory.call(this, platform, device, device.air_conditioner_id);
 
-    var that = this;
+	var that = this;
 
-    //Items specific to Thermostats:
+	//Items specific to Thermostats:
 
-    //Handle the Current State
-    this
-        .addService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-        .on('get', function(callback) {
-            if (that.device.last_reading.powered) { //I need to verify this changes when the thermostat clicks on.
-                switch (that.device.last_reading.mode) {
-                    case "cool_only":
-                        callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
-                        break;
-                    case "auto_eco": //HomeKit only accepts HEAT/COOL, so we have to determine if we are Heating or Cooling.
-                        if (that.device.last_reading.temperature > that.device.last_reading.max_set_point)
-                            callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
-                        else
-                            callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
-                        break;
-                    default: //If it is fan_only or anything else then we'll report the thermostat as off.
-                        callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
-                        break;
-                }
-            } else //For now, powered being false means it is off
-                callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
-        });
+	//Handle the Current State
+	this
+		.addService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+		.on('get', function (callback) {
+			if (that.device.last_reading.powered) { //I need to verify this changes when the thermostat clicks on.
+				switch (that.device.last_reading.mode) {
+					case "cool_only":
+						callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+						break;
+					case "auto_eco": //HomeKit only accepts HEAT/COOL, so we have to determine if we are Heating or Cooling.
+						if (that.device.last_reading.temperature > that.device.last_reading.max_set_point)
+							callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+						else
+							callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+						break;
+					default: //If it is fan_only or anything else then we'll report the thermostat as off.
+						callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+						break;
+				}
+			} else //For now, powered being false means it is off
+				callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+		});
 
-    //Handle the Target State
-    //Handle the Current State
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-        .on('get', function(callback) {
-            if (that.device.desired_state.powered) { //I need to verify this changes when the thermostat clicks on.
-                switch (that.device.desired_state.mode) {
-                    case "cool_only":
-                        callback(null, Characteristic.TargetHeatingCoolingState.COOL);
-                        break;
-                    case "auto_eco":
-                        callback(null, Characteristic.TargetHeatingCoolingState.AUTO);
-                        break;
-                    default: //The above list should be inclusive, but we need to return something if they change stuff.
-                        callback(null, Characteristic.TargetHeatingCoolingState.OFF);
-                        break;
-                }
-            } else //For now, powered being false means it is off
-                callback(null, Characteristic.TargetHeatingCoolingState.OFF);
-        })
-        .on('set', function(value, callback) {
-            switch (value) {
-                case Characteristic.TargetHeatingCoolingState.COOL:
-                    that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "cool_only"]);
-                    break;
-                case Characteristic.TargetHeatingCoolingState.AUTO:
-                    that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "auto_eco"]);
-                    break;
-                case Characteristic.TargetHeatingCoolingState.OFF:
-                    that.updatePropertyWithoutFeedback(callback, "powered", false);
-                    break;
-            }
-        });
+	//Handle the Target State
+	//Handle the Current State
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+		.on('get', function (callback) {
+			if (that.device.desired_state.powered) { //I need to verify this changes when the thermostat clicks on.
+				switch (that.device.desired_state.mode) {
+					case "cool_only":
+						callback(null, Characteristic.TargetHeatingCoolingState.COOL);
+						break;
+					case "auto_eco":
+						callback(null, Characteristic.TargetHeatingCoolingState.AUTO);
+						break;
+					default: //The above list should be inclusive, but we need to return something if they change stuff.
+						callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+						break;
+				}
+			} else //For now, powered being false means it is off
+				callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+		})
+		.on('set', function (value, callback) {
+			switch (value) {
+				case Characteristic.TargetHeatingCoolingState.COOL:
+					that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "cool_only"]);
+					break;
+				case Characteristic.TargetHeatingCoolingState.AUTO:
+					that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "auto_eco"]);
+					break;
+				case Characteristic.TargetHeatingCoolingState.OFF:
+					that.updatePropertyWithoutFeedback(callback, "powered", false);
+					break;
+			}
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.temperature);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentTemperature)
+		.on('get', function (callback) {
+			callback(null, that.device.last_reading.temperature);
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.desired_state.max_set_point);
-        })
-        .on('set', function(value, callback) {
-            that.updatePropertyWithoutFeedback(callback, "max_set_point", value);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetTemperature)
+		.on('get', function (callback) {
+			callback(null, that.device.desired_state.max_set_point);
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, "max_set_point", value);
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-        .on('get', function(callback) {
-            if (platform.temperature_unit == "C")
-                callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
-            else
-                callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+		.on('get', function (callback) {
+			if (platform.temperature_unit == "C")
+				callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+			else
+				callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
+		});
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-        .getValue();
+var loadData = function () {
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentTemperature)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetTemperature)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetTemperature)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+		.getValue();
 
 };

--- a/accessories/binary_switches.js
+++ b/accessories/binary_switches.js
@@ -1,0 +1,74 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Binary Switch Accessory
+ */
+
+function WinkSwitchAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+  // Common Base Items
+  this.device = device;
+  this.name = device.name;
+  this.log = platform.log;
+  this.platform = platform;
+  this.deviceGroup='binary_switches';
+  this.deviceId=this.device.binary_switch_id;
+
+ Service = oService;
+ Characteristic = oCharacteristic;
+ Accessory = oAccessory;
+ uuid = ouuid;
+
+  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
+  var id = uuid.generate(idKey);
+  Accessory.call(this, this.name, id);
+  this.uuid_base = id;
+
+  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+  this.log(idKey);
+  var that = this;
+  // set some basic properties (these values are arbitrary and setting them is optional)
+  this
+      .getService(Service.AccessoryInformation)
+      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+      .setCharacteristic(Characteristic.Model, this.device.model_name)
+      .setCharacteristic(Characteristic.Name, this.device.name);
+      
+  //Items specific to Light Bulbs Locks:
+     this
+      .addService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.On)
+      .on('get', function(callback) {
+        callback(null, that.device.last_reading.powered);
+      })
+      .on('set', function(value, callback) {
+        platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+      });
+}
+
+WinkSwitchAccessory.prototype = {
+  loadData: function() {
+    this.getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.On)
+      .getValue();
+  },
+  
+  getServices: function() {
+    return this.services;
+  },
+  
+  handleResponse: function(res) {
+    if (!res) {
+      return Error("No response from Wink");
+    } else if (res.errors && res.errors.length > 0) {
+      return res.errors[0];
+    } else if (res.data) {
+      this.device = res.data;
+      this.loadData();
+    }
+  }
+}
+module.exports = WinkSwitchAccessory;

--- a/accessories/binary_switches.js
+++ b/accessories/binary_switches.js
@@ -8,67 +8,97 @@ var Service, Characteristic, Accessory, uuid;
  */
 
 function WinkSwitchAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-  // Common Base Items
-  this.device = device;
-  this.name = device.name;
-  this.log = platform.log;
-  this.platform = platform;
-  this.deviceGroup='binary_switches';
-  this.deviceId=this.device.binary_switch_id;
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'binary_switches';
+    this.deviceId = this.device.binary_switch_id;
 
- Service = oService;
- Characteristic = oCharacteristic;
- Accessory = oAccessory;
- uuid = ouuid;
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
 
-  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
-  var id = uuid.generate(idKey);
-  Accessory.call(this, this.name, id);
-  this.uuid_base = id;
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
 
-  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
 
-  this.log(idKey);
-  var that = this;
-  // set some basic properties (these values are arbitrary and setting them is optional)
-  this
-      .getService(Service.AccessoryInformation)
-      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-      .setCharacteristic(Characteristic.Model, this.device.model_name)
-      .setCharacteristic(Characteristic.Name, this.device.name);
-      
-  //Items specific to Light Bulbs Locks:
-     this
-      .addService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .on('get', function(callback) {
-        callback(null, that.device.last_reading.powered);
-      })
-      .on('set', function(value, callback) {
-        platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
-      });
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
+    this
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name)
+        .setCharacteristic(Characteristic.Name, this.device.name);
+
+    if (that.device.last_reading.consumption == undefined) {
+        //If consumption is undefined then we will treat this like a lightbulb
+        this
+            .addService(Service.Lightbulb)
+            .getCharacteristic(Characteristic.On)
+            .on('get', function(callback) {
+                callback(null, that.device.last_reading.powered);
+            })
+            .on('set', function(value, callback) {
+                platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+            });
+    } else {
+        //If consumption is defined then we will treat this as an Outlet.
+        //This covers the Outlink Wall Plug.
+        this
+            .addService(Service.Outlet)
+            .getCharacteristic(Characteristic.On)
+            .on('get', function(callback) {
+                callback(null, that.device.last_reading.powered);
+            })
+            .on('set', function(value, callback) {
+                platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+            });
+        this
+            .getService(Service.Outlet)
+            .getCharacteristic(Characteristic.OutletInUse)
+            .on('get', function(callback) {
+                callback(null, (that.device.last_reading.consumption > 0.1));
+            });
+    }
 }
 
 WinkSwitchAccessory.prototype = {
-  loadData: function() {
-    this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .getValue();
-  },
-  
-  getServices: function() {
-    return this.services;
-  },
-  
-  handleResponse: function(res) {
-    if (!res) {
-      return Error("No response from Wink");
-    } else if (res.errors && res.errors.length > 0) {
-      return res.errors[0];
-    } else if (res.data) {
-      this.device = res.data;
-      this.loadData();
+    loadData: function() {
+        if (this.device.last_reading.consumption == undefined) {
+            this.getService(Service.Lightbulb)
+                .getCharacteristic(Characteristic.On)
+                .getValue();
+        } else {
+            this.getService(Service.Outlet)
+                .getCharacteristic(Characteristic.On)
+                .getValue();
+            this.getService(Service.Outlet)
+                .getCharacteristic(Characteristic.OutletInUse)
+                .getValue();
+
+        }
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
     }
-  }
 }
 module.exports = WinkSwitchAccessory;

--- a/accessories/binary_switches.js
+++ b/accessories/binary_switches.js
@@ -7,74 +7,73 @@ var WinkAccessory, Service, Characteristic, Accessory, uuid;
  *   Binary Switch Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkSwitchAccessory, WinkAccessory);
-        WinkSwitchAccessory.prototype.loadData = loadData;
-        WinkSwitchAccessory.prototype.deviceGroup = 'binary_switches';
-    }
-    return WinkSwitchAccessory;
+		inherits(WinkSwitchAccessory, WinkAccessory);
+		WinkSwitchAccessory.prototype.loadData = loadData;
+		WinkSwitchAccessory.prototype.deviceGroup = 'binary_switches';
+	}
+	return WinkSwitchAccessory;
 };
 module.exports.WinkSwitchAccessory = WinkSwitchAccessory;
 
 function WinkSwitchAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.binary_switch_id);
+	WinkAccessory.call(this, platform, device, device.binary_switch_id);
 
-    var that = this;
+	var that = this;
 
-    if (that.device.last_reading.consumption == undefined) {
-        //If consumption is undefined then we will treat this like a lightbulb
-        this
-            .addService(Service.Lightbulb)
-            .getCharacteristic(Characteristic.On)
-            .on('get', function(callback) {
-                callback(null, that.device.last_reading.powered);
-            })
-            .on('set', function(value, callback) {
-                that.updatePropertyWithoutFeedback(callback, "powered", value);
-            });
-    } else {
-        //If consumption is defined then we will treat this as an Outlet.
-        //This covers the Outlink Wall Plug.
-        this
-            .addService(Service.Outlet)
-            .getCharacteristic(Characteristic.On)
-            .on('get', function(callback) {
-                callback(null, that.device.last_reading.powered);
-            })
-            .on('set', function(value, callback) {
-                that.updatePropertyWithoutFeedback(callback, "powered", value);
-            });
-        this
-            .getService(Service.Outlet)
-            .getCharacteristic(Characteristic.OutletInUse)
-            .on('get', function(callback) {
-                callback(null, (that.device.last_reading.consumption > 0.1));
-            });
-    }
+	if (that.device.last_reading.consumption == undefined) {
+		//If consumption is undefined then we will treat this like a lightbulb
+		this
+			.addService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.On)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.powered);
+			})
+			.on('set', function (value, callback) {
+				that.updatePropertyWithoutFeedback(callback, "powered", value);
+			});
+	} else {
+		//If consumption is defined then we will treat this as an Outlet.
+		//This covers the Outlink Wall Plug.
+		this
+			.addService(Service.Outlet)
+			.getCharacteristic(Characteristic.On)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.powered);
+			})
+			.on('set', function (value, callback) {
+				that.updatePropertyWithoutFeedback(callback, "powered", value);
+			});
+		this
+			.getService(Service.Outlet)
+			.getCharacteristic(Characteristic.OutletInUse)
+			.on('get', function (callback) {
+				callback(null, (that.device.last_reading.consumption > 0.1));
+			});
+	}
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    if (this.device.last_reading.consumption == undefined) {
-        this.getService(Service.Lightbulb)
-            .getCharacteristic(Characteristic.On)
-            .getValue();
-    } else {
-        this.getService(Service.Outlet)
-            .getCharacteristic(Characteristic.On)
-            .getValue();
-        this.getService(Service.Outlet)
-            .getCharacteristic(Characteristic.OutletInUse)
-            .getValue();
+var loadData = function () {
+	if (this.device.last_reading.consumption == undefined) {
+		this.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.On)
+			.getValue();
+	} else {
+		this.getService(Service.Outlet)
+			.getCharacteristic(Characteristic.On)
+			.getValue();
+		this.getService(Service.Outlet)
+			.getCharacteristic(Characteristic.OutletInUse)
+			.getValue();
 
-    }
+	}
 };

--- a/accessories/binary_switches.js
+++ b/accessories/binary_switches.js
@@ -1,41 +1,33 @@
 var wink = require('wink-js');
 var inherits = require('util').inherits;
 
-var Service, Characteristic, Accessory, uuid;
+var WinkAccessory, Service, Characteristic, Accessory, uuid;
 
 /*
  *   Binary Switch Accessory
  */
 
-function WinkSwitchAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-    // Common Base Items
-    this.device = device;
-    this.name = device.name;
-    this.log = platform.log;
-    this.platform = platform;
-    this.deviceGroup = 'binary_switches';
-    this.deviceId = this.device.binary_switch_id;
+module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
+{
+    if (oWinkAccessory) {
+        WinkAccessory = oWinkAccessory;
+        Accessory = oAccessory;
+        Service = oService;
+        Characteristic = oCharacteristic;
+        uuid = ouuid;
 
-    Service = oService;
-    Characteristic = oCharacteristic;
-    Accessory = oAccessory;
-    uuid = ouuid;
+        inherits(WinkSwitchAccessory, WinkAccessory);
+        WinkSwitchAccessory.prototype.loadData = loadData;
+        WinkSwitchAccessory.prototype.deviceGroup = 'binary_switches';
+    }
+    return WinkSwitchAccessory;
+};
+module.exports.WinkSwitchAccessory = WinkSwitchAccessory;
 
-    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
-    var id = uuid.generate(idKey);
-    Accessory.call(this, this.name, id);
-    this.uuid_base = id;
+function WinkSwitchAccessory(platform, device) {
+    WinkAccessory.call(this, platform, device, device.binary_switch_id);
 
-    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
-
-    //this.log(idKey+' '+ JSON.stringify(device));
     var that = this;
-    // set some basic properties (these values are arbitrary and setting them is optional)
-    this
-        .getService(Service.AccessoryInformation)
-        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-        .setCharacteristic(Characteristic.Model, this.device.model_name)
-        .setCharacteristic(Characteristic.Name, this.device.name);
 
     if (that.device.last_reading.consumption == undefined) {
         //If consumption is undefined then we will treat this like a lightbulb
@@ -46,7 +38,7 @@ function WinkSwitchAccessory(platform, device, oService, oCharacteristic, oAcces
                 callback(null, that.device.last_reading.powered);
             })
             .on('set', function(value, callback) {
-                platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+                that.updatePropertyWithoutFeedback(callback, "powered", value);
             });
     } else {
         //If consumption is defined then we will treat this as an Outlet.
@@ -58,7 +50,7 @@ function WinkSwitchAccessory(platform, device, oService, oCharacteristic, oAcces
                 callback(null, that.device.last_reading.powered);
             })
             .on('set', function(value, callback) {
-                platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+                that.updatePropertyWithoutFeedback(callback, "powered", value);
             });
         this
             .getService(Service.Outlet)
@@ -67,38 +59,22 @@ function WinkSwitchAccessory(platform, device, oService, oCharacteristic, oAcces
                 callback(null, (that.device.last_reading.consumption > 0.1));
             });
     }
+
+    this.loadData();
 }
 
-WinkSwitchAccessory.prototype = {
-    loadData: function() {
-        if (this.device.last_reading.consumption == undefined) {
-            this.getService(Service.Lightbulb)
-                .getCharacteristic(Characteristic.On)
-                .getValue();
-        } else {
-            this.getService(Service.Outlet)
-                .getCharacteristic(Characteristic.On)
-                .getValue();
-            this.getService(Service.Outlet)
-                .getCharacteristic(Characteristic.OutletInUse)
-                .getValue();
+var loadData = function() {
+    if (this.device.last_reading.consumption == undefined) {
+        this.getService(Service.Lightbulb)
+            .getCharacteristic(Characteristic.On)
+            .getValue();
+    } else {
+        this.getService(Service.Outlet)
+            .getCharacteristic(Characteristic.On)
+            .getValue();
+        this.getService(Service.Outlet)
+            .getCharacteristic(Characteristic.OutletInUse)
+            .getValue();
 
-        }
-    },
-
-    getServices: function() {
-        return this.services;
-    },
-
-    handleResponse: function(res) {
-        if (!res) {
-            return Error("No response from Wink");
-        } else if (res.errors && res.errors.length > 0) {
-            return res.errors[0];
-        } else if (res.data) {
-            this.device = res.data;
-            this.loadData();
-        }
     }
-}
-module.exports = WinkSwitchAccessory;
+};

--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -8,91 +8,119 @@ var Service, Characteristic, Accessory, uuid;
  */
 
 function WinkGarageDoorAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-  // Common Base Items
-  this.device = device;
-  this.name = device.name;
-  this.log = platform.log;
-  this.platform = platform;
-  this.deviceGroup='garage_doors';
-  this.deviceId=this.device.garage_door_id;
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'garage_doors';
+    this.deviceId = this.device.garage_door_id;
 
- Service = oService;
- Characteristic = oCharacteristic;
- Accessory = oAccessory;
- uuid = ouuid;
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
 
-  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
-  var id = uuid.generate(idKey);
-  Accessory.call(this, this.name, id);
-  this.uuid_base = id;
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
 
-  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
 
-  this.log(idKey);
-  var that = this;
-  // set some basic properties (these values are arbitrary and setting them is optional)
-  this
-      .getService(Service.AccessoryInformation)
-      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-      .setCharacteristic(Characteristic.Model, this.device.model_name)
-      .setCharacteristic(Characteristic.Name, this.device.name);
-      
-  //Items specific to Garage Doors:
-     this
-      .addService(Service.GarageDoorOpener)
-      .getCharacteristic(Characteristic.TargetDoorState)
-      .on('get', function(callback) {
-        if (that.device.desired_state.position == 0)
-          callback(null, Characteristic.TargetDoorState.CLOSED);
-        else if (that.device.desired_state.position == 1)
-          callback(null, Characteristic.TargetDoorState.OPEN);
-      })
-      .on('set', function(value, callback) {
-        if (value == Characteristic.TargetDoorState.OPEN)
-          platform.UpdateWinkProperty_noFeedback(that, callback, "position", 1);
-        else if (value == Characteristic.TargetDoorState.CLOSED)
-          platform.UpdateWinkProperty_noFeedback(that, callback, "position", 0);
-      });
-      
-      this
-      .getService(Service.GarageDoorOpener)
-      .getCharacteristic(Characteristic.CurrentDoorState)
-      .on('get', function(callback) {
-        if (that.device.last_reading.position == 0)
-          callback(null, Characteristic.CurrentDoorState.CLOSED);
-        else if (that.device.last_reading.position == 1)
-          callback(null, Characteristic.CurrentDoorState.OPEN);      
-      })
-     this
-      .getService(Service.GarageDoorOpener)
-      .setCharacteristic(Characteristic.ObstructionDetected, false);
-      
-     
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
+    this
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name)
+        .setCharacteristic(Characteristic.Name, this.device.name);
+
+    //Items specific to Garage Doors:
+    this
+        .addService(Service.GarageDoorOpener)
+        .getCharacteristic(Characteristic.TargetDoorState)
+        .on('get', function(callback) {
+            if (that.device.desired_state.position == 0)
+                callback(null, Characteristic.TargetDoorState.CLOSED);
+            else if (that.device.desired_state.position == 1)
+                callback(null, Characteristic.TargetDoorState.OPEN);
+        })
+        .on('set', function(value, callback) {
+            if (value == Characteristic.TargetDoorState.OPEN)
+                platform.UpdateWinkProperty_withFeedback(that, callback, "position", 1);
+            else if (value == Characteristic.TargetDoorState.CLOSED)
+                platform.UpdateWinkProperty_withFeedback(that, callback, "position", 0);
+        });
+
+    this
+        .getService(Service.GarageDoorOpener)
+        .getCharacteristic(Characteristic.CurrentDoorState)
+        .on('get', function(callback) {
+            if (that.device.last_reading.position == 0)
+                callback(null, Characteristic.CurrentDoorState.CLOSED);
+            else if (that.device.last_reading.position == 1)
+                callback(null, Characteristic.CurrentDoorState.OPEN);
+        })
+    this
+        .getService(Service.GarageDoorOpener)
+        .setCharacteristic(Characteristic.ObstructionDetected, false);
+
+    //Track the Battery Level
+    if (that.device.last_reading.battery !== undefined) {
+        this.addService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
+            .on('get', function(callback) {
+                callback(null, Math.floor(that.device.last_reading.battery * 100));
+            });
+
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
+            .on('get', function(callback) {
+                if (that.device.last_reading.battery < 0.25)
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+                else
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+            });
+
+        this.getService(Service.BatteryService)
+            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+    }
+    //End Battery Level Tracking     
 }
 
 WinkGarageDoorAccessory.prototype = {
-  loadData: function() {
-    this.getService(Service.GarageDoorOpener)
-      .getCharacteristic(Characteristic.CurrentDoorState)
-      .getValue();
-    this.getService(Service.GarageDoorOpener)
-      .getCharacteristic(Characteristic.TargetDoorState)
-      .getValue();
-  },
-  
-  getServices: function() {
-    return this.services;
-  },
-  
-  handleResponse: function(res) {
-    if (!res) {
-      return Error("No response from Wink");
-    } else if (res.errors && res.errors.length > 0) {
-      return res.errors[0];
-    } else if (res.data) {
-      this.device = res.data;
-      this.loadData();
+    loadData: function() {
+        this.getService(Service.GarageDoorOpener)
+            .getCharacteristic(Characteristic.CurrentDoorState)
+            .getValue();
+        this.getService(Service.GarageDoorOpener)
+            .getCharacteristic(Characteristic.TargetDoorState)
+            .getValue();
+        if (this.device.last_reading.battery !== undefined) {
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.BatteryLevel)
+                .getValue
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.StatusLowBattery)
+                .getValue
+        }
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
     }
-  }
 }
 module.exports = WinkGarageDoorAccessory;

--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -1,4 +1,3 @@
-var wink = require('wink-js');
 var inherits = require('util').inherits;
 
 var WinkAccessory, Accessory, Service, Characteristic, uuid;
@@ -53,7 +52,8 @@ function WinkGarageDoorAccessory(platform, device) {
 				callback(null, Characteristic.CurrentDoorState.CLOSED);
 			else if (that.device.last_reading.position == 1)
 				callback(null, Characteristic.CurrentDoorState.OPEN);
-		})
+		});
+
 	this
 		.getService(Service.GarageDoorOpener)
 		.setCharacteristic(Characteristic.ObstructionDetected, false);

--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -7,96 +7,95 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Garage Door Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkGarageDoorAccessory, WinkAccessory);
-        WinkGarageDoorAccessory.prototype.loadData = loadData;
-        WinkGarageDoorAccessory.prototype.deviceGroup = 'garage_doors';
-    }
-    return WinkGarageDoorAccessory;
+		inherits(WinkGarageDoorAccessory, WinkAccessory);
+		WinkGarageDoorAccessory.prototype.loadData = loadData;
+		WinkGarageDoorAccessory.prototype.deviceGroup = 'garage_doors';
+	}
+	return WinkGarageDoorAccessory;
 };
 module.exports.WinkGarageDoorAccessory = WinkGarageDoorAccessory;
 
 function WinkGarageDoorAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.garage_door_id);
+	WinkAccessory.call(this, platform, device, device.garage_door_id);
 
-    var that = this;
+	var that = this;
 
-    //Items specific to Garage Doors:
-    this
-        .addService(Service.GarageDoorOpener)
-        .getCharacteristic(Characteristic.TargetDoorState)
-        .on('get', function(callback) {
-            if (that.device.desired_state.position == 0)
-                callback(null, Characteristic.TargetDoorState.CLOSED);
-            else if (that.device.desired_state.position == 1)
-                callback(null, Characteristic.TargetDoorState.OPEN);
-        })
-        .on('set', function(value, callback) {
-            if (value == Characteristic.TargetDoorState.OPEN)
-                that.updatePropertyWithFeedback(callback, "position", 1);
-            else if (value == Characteristic.TargetDoorState.CLOSED)
-                that.updatePropertyWithFeedback(callback, "position", 0);
-        });
+	//Items specific to Garage Doors:
+	this
+		.addService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.TargetDoorState)
+		.on('get', function (callback) {
+			if (that.device.desired_state.position == 0)
+				callback(null, Characteristic.TargetDoorState.CLOSED);
+			else if (that.device.desired_state.position == 1)
+				callback(null, Characteristic.TargetDoorState.OPEN);
+		})
+		.on('set', function (value, callback) {
+			if (value == Characteristic.TargetDoorState.OPEN)
+				that.updatePropertyWithFeedback(callback, "position", 1);
+			else if (value == Characteristic.TargetDoorState.CLOSED)
+				that.updatePropertyWithFeedback(callback, "position", 0);
+		});
 
-    this
-        .getService(Service.GarageDoorOpener)
-        .getCharacteristic(Characteristic.CurrentDoorState)
-        .on('get', function(callback) {
-            if (that.device.last_reading.position == 0)
-                callback(null, Characteristic.CurrentDoorState.CLOSED);
-            else if (that.device.last_reading.position == 1)
-                callback(null, Characteristic.CurrentDoorState.OPEN);
-        })
-    this
-        .getService(Service.GarageDoorOpener)
-        .setCharacteristic(Characteristic.ObstructionDetected, false);
+	this
+		.getService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.CurrentDoorState)
+		.on('get', function (callback) {
+			if (that.device.last_reading.position == 0)
+				callback(null, Characteristic.CurrentDoorState.CLOSED);
+			else if (that.device.last_reading.position == 1)
+				callback(null, Characteristic.CurrentDoorState.OPEN);
+		})
+	this
+		.getService(Service.GarageDoorOpener)
+		.setCharacteristic(Characteristic.ObstructionDetected, false);
 
-    //Track the Battery Level
-    if (that.device.last_reading.battery !== undefined) {
-        this.addService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .on('get', function(callback) {
-                callback(null, Math.floor(that.device.last_reading.battery * 100));
-            });
+	//Track the Battery Level
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.battery * 100));
+			});
 
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .on('get', function(callback) {
-                if (that.device.last_reading.battery < 0.25)
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-                else
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-            });
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.battery < 0.25)
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
 
-        this.getService(Service.BatteryService)
-            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
-    }
-    //End Battery Level Tracking
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
+	//End Battery Level Tracking
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    this.getService(Service.GarageDoorOpener)
-        .getCharacteristic(Characteristic.CurrentDoorState)
-        .getValue();
-    this.getService(Service.GarageDoorOpener)
-        .getCharacteristic(Characteristic.TargetDoorState)
-        .getValue();
-    if (this.device.last_reading.battery !== undefined) {
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .getValue();
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .getValue();
-    }
+var loadData = function () {
+	this.getService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.CurrentDoorState)
+		.getValue();
+	this.getService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.TargetDoorState)
+		.getValue();
+	if (this.device.last_reading.battery !== undefined) {
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.getValue();
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.getValue();
+	}
 };

--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -1,0 +1,98 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Garage Door Accessory
+ */
+
+function WinkGarageDoorAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+  // Common Base Items
+  this.device = device;
+  this.name = device.name;
+  this.log = platform.log;
+  this.platform = platform;
+  this.deviceGroup='garage_doors';
+  this.deviceId=this.device.garage_door_id;
+
+ Service = oService;
+ Characteristic = oCharacteristic;
+ Accessory = oAccessory;
+ uuid = ouuid;
+
+  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
+  var id = uuid.generate(idKey);
+  Accessory.call(this, this.name, id);
+  this.uuid_base = id;
+
+  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+  this.log(idKey);
+  var that = this;
+  // set some basic properties (these values are arbitrary and setting them is optional)
+  this
+      .getService(Service.AccessoryInformation)
+      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+      .setCharacteristic(Characteristic.Model, this.device.model_name)
+      .setCharacteristic(Characteristic.Name, this.device.name);
+      
+  //Items specific to Garage Doors:
+     this
+      .addService(Service.GarageDoorOpener)
+      .getCharacteristic(Characteristic.TargetDoorState)
+      .on('get', function(callback) {
+        if (that.device.desired_state.position == 0)
+          callback(null, Characteristic.TargetDoorState.CLOSED);
+        else if (that.device.desired_state.position == 1)
+          callback(null, Characteristic.TargetDoorState.OPEN);
+      })
+      .on('set', function(value, callback) {
+        if (value == Characteristic.TargetDoorState.OPEN)
+          platform.UpdateWinkProperty_noFeedback(that, callback, "position", 1);
+        else if (value == Characteristic.TargetDoorState.CLOSED)
+          platform.UpdateWinkProperty_noFeedback(that, callback, "position", 0);
+      });
+      
+      this
+      .getService(Service.GarageDoorOpener)
+      .getCharacteristic(Characteristic.CurrentDoorState)
+      .on('get', function(callback) {
+        if (that.device.last_reading.position == 0)
+          callback(null, Characteristic.CurrentDoorState.CLOSED);
+        else if (that.device.last_reading.position == 1)
+          callback(null, Characteristic.CurrentDoorState.OPEN);      
+      })
+     this
+      .getService(Service.GarageDoorOpener)
+      .setCharacteristic(Characteristic.ObstructionDetected, false);
+      
+     
+}
+
+WinkGarageDoorAccessory.prototype = {
+  loadData: function() {
+    this.getService(Service.GarageDoorOpener)
+      .getCharacteristic(Characteristic.CurrentDoorState)
+      .getValue();
+    this.getService(Service.GarageDoorOpener)
+      .getCharacteristic(Characteristic.TargetDoorState)
+      .getValue();
+  },
+  
+  getServices: function() {
+    return this.services;
+  },
+  
+  handleResponse: function(res) {
+    if (!res) {
+      return Error("No response from Wink");
+    } else if (res.errors && res.errors.length > 0) {
+      return res.errors[0];
+    } else if (res.data) {
+      this.device = res.data;
+      this.loadData();
+    }
+  }
+}
+module.exports = WinkGarageDoorAccessory;

--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -1,41 +1,33 @@
 var wink = require('wink-js');
 var inherits = require('util').inherits;
 
-var Service, Characteristic, Accessory, uuid;
+var WinkAccessory, Accessory, Service, Characteristic, uuid;
 
 /*
  *   Garage Door Accessory
  */
 
-function WinkGarageDoorAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-    // Common Base Items
-    this.device = device;
-    this.name = device.name;
-    this.log = platform.log;
-    this.platform = platform;
-    this.deviceGroup = 'garage_doors';
-    this.deviceId = this.device.garage_door_id;
+module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
+{
+    if (oWinkAccessory) {
+        WinkAccessory = oWinkAccessory;
+        Accessory = oAccessory;
+        Service = oService;
+        Characteristic = oCharacteristic;
+        uuid = ouuid;
 
-    Service = oService;
-    Characteristic = oCharacteristic;
-    Accessory = oAccessory;
-    uuid = ouuid;
+        inherits(WinkGarageDoorAccessory, WinkAccessory);
+        WinkGarageDoorAccessory.prototype.loadData = loadData;
+        WinkGarageDoorAccessory.prototype.deviceGroup = 'garage_doors';
+    }
+    return WinkGarageDoorAccessory;
+};
+module.exports.WinkGarageDoorAccessory = WinkGarageDoorAccessory;
 
-    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
-    var id = uuid.generate(idKey);
-    Accessory.call(this, this.name, id);
-    this.uuid_base = id;
+function WinkGarageDoorAccessory(platform, device) {
+    WinkAccessory.call(this, platform, device, device.garage_door_id);
 
-    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
-
-    //this.log(idKey+' '+ JSON.stringify(device));
     var that = this;
-    // set some basic properties (these values are arbitrary and setting them is optional)
-    this
-        .getService(Service.AccessoryInformation)
-        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-        .setCharacteristic(Characteristic.Model, this.device.model_name)
-        .setCharacteristic(Characteristic.Name, this.device.name);
 
     //Items specific to Garage Doors:
     this
@@ -49,9 +41,9 @@ function WinkGarageDoorAccessory(platform, device, oService, oCharacteristic, oA
         })
         .on('set', function(value, callback) {
             if (value == Characteristic.TargetDoorState.OPEN)
-                platform.UpdateWinkProperty_withFeedback(that, callback, "position", 1);
+                that.updatePropertyWithFeedback(callback, "position", 1);
             else if (value == Characteristic.TargetDoorState.CLOSED)
-                platform.UpdateWinkProperty_withFeedback(that, callback, "position", 0);
+                that.updatePropertyWithFeedback(callback, "position", 0);
         });
 
     this
@@ -87,40 +79,24 @@ function WinkGarageDoorAccessory(platform, device, oService, oCharacteristic, oA
         this.getService(Service.BatteryService)
             .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
     }
-    //End Battery Level Tracking     
+    //End Battery Level Tracking
+
+    this.loadData();
 }
 
-WinkGarageDoorAccessory.prototype = {
-    loadData: function() {
-        this.getService(Service.GarageDoorOpener)
-            .getCharacteristic(Characteristic.CurrentDoorState)
+var loadData = function() {
+    this.getService(Service.GarageDoorOpener)
+        .getCharacteristic(Characteristic.CurrentDoorState)
+        .getValue();
+    this.getService(Service.GarageDoorOpener)
+        .getCharacteristic(Characteristic.TargetDoorState)
+        .getValue();
+    if (this.device.last_reading.battery !== undefined) {
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
             .getValue();
-        this.getService(Service.GarageDoorOpener)
-            .getCharacteristic(Characteristic.TargetDoorState)
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
             .getValue();
-        if (this.device.last_reading.battery !== undefined) {
-            this.getService(Service.BatteryService)
-                .getCharacteristic(Characteristic.BatteryLevel)
-                .getValue
-            this.getService(Service.BatteryService)
-                .getCharacteristic(Characteristic.StatusLowBattery)
-                .getValue
-        }
-    },
-
-    getServices: function() {
-        return this.services;
-    },
-
-    handleResponse: function(res) {
-        if (!res) {
-            return Error("No response from Wink");
-        } else if (res.errors && res.errors.length > 0) {
-            return res.errors[0];
-        } else if (res.data) {
-            this.device = res.data;
-            this.loadData();
-        }
     }
-}
-module.exports = WinkGarageDoorAccessory;
+};

--- a/accessories/light_bulbs.js
+++ b/accessories/light_bulbs.js
@@ -21,7 +21,7 @@ module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic
 	}
 	return WinkLightAccessory;
 };
-module.exports.WinkGarageDoorAccessory = WinkLightAccessory;
+module.exports.WinkLightAccessory = WinkLightAccessory;
 
 function WinkLightAccessory(platform, device) {
 	WinkAccessory.call(this, platform, device, device.light_bulb_id);

--- a/accessories/light_bulbs.js
+++ b/accessories/light_bulbs.js
@@ -7,96 +7,97 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Light Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkLightAccessory, WinkAccessory);
-        WinkLightAccessory.prototype.loadData = loadData;
-        WinkLightAccessory.prototype.deviceGroup = 'light_bulbs';
-    }
-    return WinkLightAccessory;
+		inherits(WinkLightAccessory, WinkAccessory);
+		WinkLightAccessory.prototype.loadData = loadData;
+		WinkLightAccessory.prototype.deviceGroup = 'light_bulbs';
+	}
+	return WinkLightAccessory;
 };
 module.exports.WinkGarageDoorAccessory = WinkLightAccessory;
 
 function WinkLightAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.light_bulb_id);
+	WinkAccessory.call(this, platform, device, device.light_bulb_id);
 
-  var that = this;
-  
-  //Items specific to Light Bulbs Locks:
-     this
-      .addService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .on('get', function(callback) {
-        callback(null, that.device.last_reading.powered);
-      })
-      .on('set', function(value, callback) {
-        that.updatePropertyWithoutFeedback(callback, "powered", value);
-      });
+	var that = this;
 
-  if (that.device.desired_state.brightness !== undefined)      
-     this
-      .getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Brightness)
-      .on('get', function(callback) {
-        callback(null, Math.floor(that.device.last_reading.brightness*100));
-      })
-      .on('set', function(value, callback) {
-        that.updatePropertyWithoutFeedback(callback, "brightness", value/100);
-      });
+	//Items specific to Light Bulbs Locks:
+	this
+		.addService(Service.Lightbulb)
+		.getCharacteristic(Characteristic.On)
+		.on('get', function (callback) {
+			callback(null, that.device.last_reading.powered);
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, "powered", value);
+		});
 
-  if (that.device.desired_state.color_model != undefined)
-        that.updatePropertyWithoutFeedback(function(){ return 0; }, "color_model", "hsb");
-    
+	if (that.device.desired_state.brightness !== undefined)
+		this
+			.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.Brightness)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.brightness * 100));
+			})
+			.on('set', function (value, callback) {
+				that.updatePropertyWithoutFeedback(callback, "brightness", value / 100);
+			});
 
-  if (that.device.desired_state.hue !== undefined)      
-     this
-      .getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Hue)
-      .on('get', function(callback) {
-        callback(null, Math.floor(that.device.last_reading.hue*360));
-      })
-      .on('set', function(value, callback) {
-        that.updatePropertyWithoutFeedback(callback, "hue", value/360);
-      });
+	if (that.device.desired_state.color_model != undefined)
+		that.updatePropertyWithoutFeedback(function () {
+			return 0;
+		}, "color_model", "hsb");
 
-  if (that.device.desired_state.saturation !== undefined)      
-     this
-      .getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Saturation)
-      .on('get', function(callback) {
-        callback(null, Math.floor(that.device.last_reading.saturation*100));
-      })
-      .on('set', function(value, callback) {
-        that.updatePropertyWithoutFeedback(callback, "saturation", value/100);
-      });
 
-    this.loadData();
+	if (that.device.desired_state.hue !== undefined)
+		this
+			.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.Hue)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.hue * 360));
+			})
+			.on('set', function (value, callback) {
+				that.updatePropertyWithoutFeedback(callback, "hue", value / 360);
+			});
+
+	if (that.device.desired_state.saturation !== undefined)
+		this
+			.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.Saturation)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.saturation * 100));
+			})
+			.on('set', function (value, callback) {
+				that.updatePropertyWithoutFeedback(callback, "saturation", value / 100);
+			});
+
+	this.loadData();
 }
 
-var loadData = function() {
-    this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .getValue();
+var loadData = function () {
+	this.getService(Service.Lightbulb)
+		.getCharacteristic(Characteristic.On)
+		.getValue();
 
-    if (this.device.desired_state.brightness !== undefined)
-    this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Brightness)
-      .getValue();
+	if (this.device.desired_state.brightness !== undefined)
+		this.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.Brightness)
+			.getValue();
 
-    if (this.device.desired_state.hue !== undefined)
-    this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Hue)
-      .getValue();
+	if (this.device.desired_state.hue !== undefined)
+		this.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.Hue)
+			.getValue();
 
-    if (this.device.desired_state.saturation !== undefined)
-    this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Saturation)
-      .getValue();
+	if (this.device.desired_state.saturation !== undefined)
+		this.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.Saturation)
+			.getValue();
 };

--- a/accessories/light_bulbs.js
+++ b/accessories/light_bulbs.js
@@ -1,0 +1,89 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+/*
+ *   Generic Accessory
+ */
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Light Accessory
+ */
+
+function WinkLightAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+  // Common Base Items
+  this.device = device;
+  this.name = device.name;
+  this.log = platform.log;
+  this.platform = platform;
+  this.deviceGroup='light_bulbs';
+  this.deviceId=this.device.light_bulb_id;
+
+ Service = oService;
+ Characteristic = oCharacteristic;
+ Accessory = oAccessory;
+ uuid = ouuid;
+
+  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
+  var id = uuid.generate(idKey);
+  Accessory.call(this, this.name, id);
+  this.uuid_base = id;
+
+  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+  this.log(idKey);
+  var that = this;
+  // set some basic properties (these values are arbitrary and setting them is optional)
+  this
+      .getService(Service.AccessoryInformation)
+      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+      .setCharacteristic(Characteristic.Model, this.device.model_name);
+  
+  //Items specific to Light Bulbs Locks:
+     this
+      .addService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.On)
+      .on('get', function(callback) {
+        callback(null, that.device.last_reading.powered);
+      })
+      .on('set', function(value, callback) {
+        platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+      });
+      
+     this
+      .getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.Brightness)
+      .on('get', function(callback) {
+        callback(null, Math.floor(that.device.last_reading.brightness*100));
+      })
+      .on('set', function(value, callback) {
+        platform.UpdateWinkProperty_noFeedback(that, callback, "brightness", value/100);
+      });
+}
+
+WinkLightAccessory.prototype = {
+  loadData: function() {
+    this.getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.On)
+      .getValue();
+    this.getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.Brightness)
+      .getValue();
+  },
+  
+  getServices: function() {
+    return this.services;
+  },
+  
+  handleResponse: function(res) {
+    if (!res) {
+      return Error("No response from Wink");
+    } else if (res.errors && res.errors.length > 0) {
+      return res.errors[0];
+    } else if (res.data) {
+      this.device = res.data;
+      this.loadData();
+    }
+  }
+}
+module.exports = WinkLightAccessory;

--- a/accessories/light_bulbs.js
+++ b/accessories/light_bulbs.js
@@ -1,9 +1,6 @@
 var wink = require('wink-js');
 var inherits = require('util').inherits;
 
-/*
- *   Generic Accessory
- */
 var Service, Characteristic, Accessory, uuid;
 
 /*
@@ -24,14 +21,14 @@ function WinkLightAccessory(platform, device, oService, oCharacteristic, oAccess
  Accessory = oAccessory;
  uuid = ouuid;
 
-  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
+  var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
   var id = uuid.generate(idKey);
   Accessory.call(this, this.name, id);
   this.uuid_base = id;
 
   this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
 
-  this.log(idKey);
+  //this.log(idKey+' '+ JSON.stringify(device));
   var that = this;
   // set some basic properties (these values are arbitrary and setting them is optional)
   this
@@ -49,7 +46,8 @@ function WinkLightAccessory(platform, device, oService, oCharacteristic, oAccess
       .on('set', function(value, callback) {
         platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
       });
-      
+
+  if (that.device.desired_state.brightness !== undefined)      
      this
       .getService(Service.Lightbulb)
       .getCharacteristic(Characteristic.Brightness)
@@ -59,6 +57,28 @@ function WinkLightAccessory(platform, device, oService, oCharacteristic, oAccess
       .on('set', function(value, callback) {
         platform.UpdateWinkProperty_noFeedback(that, callback, "brightness", value/100);
       });
+
+  if (that.device.desired_state.hue !== undefined)      
+     this
+      .getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.Hue)
+      .on('get', function(callback) {
+        callback(null, that.device.last_reading.hue);
+      })
+      .on('set', function(value, callback) {
+        platform.UpdateWinkProperty_noFeedback(that, callback, "hue", value);
+      });
+
+  if (that.device.desired_state.saturation !== undefined)      
+     this
+      .getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.Saturation)
+      .on('get', function(callback) {
+        callback(null, that.device.last_reading.saturation);
+      })
+      .on('set', function(value, callback) {
+        platform.UpdateWinkProperty_noFeedback(that, callback, "saturation", value);
+      });
 }
 
 WinkLightAccessory.prototype = {
@@ -66,8 +86,20 @@ WinkLightAccessory.prototype = {
     this.getService(Service.Lightbulb)
       .getCharacteristic(Characteristic.On)
       .getValue();
+      
+  if (this.device.desired_state.brightness !== undefined)      
     this.getService(Service.Lightbulb)
       .getCharacteristic(Characteristic.Brightness)
+      .getValue();
+
+  if (this.device.desired_state.hue !== undefined)      
+    this.getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.Hue)
+      .getValue();
+
+  if (this.device.desired_state.saturation !== undefined)      
+    this.getService(Service.Lightbulb)
+      .getCharacteristic(Characteristic.Saturation)
       .getValue();
   },
   

--- a/accessories/locks.js
+++ b/accessories/locks.js
@@ -1,0 +1,113 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+/*
+ *   Generic Accessory
+ */
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Lock Accessory
+ */
+
+function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+  // Common Base Items
+  this.device = device;
+  this.name = device.name;
+  this.log = platform.log;
+  this.platform = platform;
+  this.deviceGroup='locks';
+  this.deviceId=this.device.lock_id;
+
+ Service = oService;
+ Characteristic = oCharacteristic;
+ Accessory = oAccessory;
+ uuid = ouuid;
+
+  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
+  var id = uuid.generate(idKey);
+  Accessory.call(this, this.name, id);
+  this.uuid_base = id;
+
+  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+  this.log(idKey);
+  var that = this;
+  // set some basic properties (these values are arbitrary and setting them is optional)
+  this
+      .getService(Service.AccessoryInformation)
+      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+      .setCharacteristic(Characteristic.Model, this.device.model_name);
+  
+  //Items specific to Door Locks:
+     this
+      .addService(Service.LockMechanism)
+      .getCharacteristic(Characteristic.LockCurrentState)
+      .on('get', function(callback) {
+        switch (that.device.last_reading.locked) {
+            case true:
+              callback(null, Characteristic.LockCurrentState.SECURED);
+              break;
+            case false:
+              callback(null, Characteristic.LockCurrentState.UNSECURED);
+              break;
+            default:
+              callback(null, Characteristic.LockCurrentState.UNKNOWN);
+              break;
+        }
+      });
+      
+    this
+      .getService(Service.LockMechanism)
+      .getCharacteristic(Characteristic.LockTargetState)
+      .on('get', function(callback) {
+        switch (that.device.desired_state.locked) {
+            case true:
+              callback(null, Characteristic.LockCurrentState.SECURED);
+              break;
+            case false:
+              callback(null, Characteristic.LockCurrentState.UNSECURED);
+              break;
+            default:
+              callback(null, Characteristic.LockCurrentState.UNKNOWN);
+              break;
+        }
+      })
+      .on('set', function(value, callback) {
+        switch(value) {
+          case Characteristic.LockTargetState.SECURED:
+            platform.UpdateWinkProperty_noFeedback(that, callback, "locked", true);
+            break;
+          case Characteristic.LockTargetState.UNSECURED:
+            platform.UpdateWinkProperty_noFeedback(that, callback, "locked", false);
+            break;
+        }
+      });  
+}
+
+WinkLockAccessory.prototype = {
+  loadData: function() {
+    this.getService(Service.LockMechanism)
+      .getCharacteristic(Characteristic.LockCurrentState)
+      .getValue();
+    this.getService(Service.LockMechanism)
+      .getCharacteristic(Characteristic.LockTargetState)
+      .getValue();
+  },
+  
+  getServices: function() {
+    return this.services;
+  },
+  
+  handleResponse: function(res) {
+    if (!res) {
+      return Error("No response from Wink");
+    } else if (res.errors && res.errors.length > 0) {
+      return res.errors[0];
+    } else if (res.data) {
+      this.device = res.data;
+      this.loadData();
+    }
+  }
+}
+module.exports = WinkLockAccessory;

--- a/accessories/locks.js
+++ b/accessories/locks.js
@@ -11,103 +11,134 @@ var Service, Characteristic, Accessory, uuid;
  */
 
 function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-  // Common Base Items
-  this.device = device;
-  this.name = device.name;
-  this.log = platform.log;
-  this.platform = platform;
-  this.deviceGroup='locks';
-  this.deviceId=this.device.lock_id;
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'locks';
+    this.deviceId = this.device.lock_id;
 
- Service = oService;
- Characteristic = oCharacteristic;
- Accessory = oAccessory;
- uuid = ouuid;
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
 
-  var idKey = 'hbdev:wink:' + this.device.name + ':' + this.deviceGroup + ':' + this.deviceId;
-  var id = uuid.generate(idKey);
-  Accessory.call(this, this.name, id);
-  this.uuid_base = id;
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
 
-  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
 
-  this.log(idKey);
-  var that = this;
-  // set some basic properties (these values are arbitrary and setting them is optional)
-  this
-      .getService(Service.AccessoryInformation)
-      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-      .setCharacteristic(Characteristic.Model, this.device.model_name);
-  
-  //Items specific to Door Locks:
-     this
-      .addService(Service.LockMechanism)
-      .getCharacteristic(Characteristic.LockCurrentState)
-      .on('get', function(callback) {
-        switch (that.device.last_reading.locked) {
-            case true:
-              callback(null, Characteristic.LockCurrentState.SECURED);
-              break;
-            case false:
-              callback(null, Characteristic.LockCurrentState.UNSECURED);
-              break;
-            default:
-              callback(null, Characteristic.LockCurrentState.UNKNOWN);
-              break;
-        }
-      });
-      
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
     this
-      .getService(Service.LockMechanism)
-      .getCharacteristic(Characteristic.LockTargetState)
-      .on('get', function(callback) {
-        switch (that.device.desired_state.locked) {
-            case true:
-              callback(null, Characteristic.LockCurrentState.SECURED);
-              break;
-            case false:
-              callback(null, Characteristic.LockCurrentState.UNSECURED);
-              break;
-            default:
-              callback(null, Characteristic.LockCurrentState.UNKNOWN);
-              break;
-        }
-      })
-      .on('set', function(value, callback) {
-        switch(value) {
-          case Characteristic.LockTargetState.SECURED:
-            platform.UpdateWinkProperty_noFeedback(that, callback, "locked", true);
-            break;
-          case Characteristic.LockTargetState.UNSECURED:
-            platform.UpdateWinkProperty_noFeedback(that, callback, "locked", false);
-            break;
-        }
-      });  
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name);
+
+    //Items specific to Door Locks:
+    this
+        .addService(Service.LockMechanism)
+        .getCharacteristic(Characteristic.LockCurrentState)
+        .on('get', function(callback) {
+            switch (that.device.last_reading.locked) {
+                case true:
+                    callback(null, Characteristic.LockCurrentState.SECURED);
+                    break;
+                case false:
+                    callback(null, Characteristic.LockCurrentState.UNSECURED);
+                    break;
+                default:
+                    callback(null, Characteristic.LockCurrentState.UNKNOWN);
+                    break;
+            }
+        });
+
+    this
+        .getService(Service.LockMechanism)
+        .getCharacteristic(Characteristic.LockTargetState)
+        .on('get', function(callback) {
+            switch (that.device.desired_state.locked) {
+                case true:
+                    callback(null, Characteristic.LockCurrentState.SECURED);
+                    break;
+                case false:
+                    callback(null, Characteristic.LockCurrentState.UNSECURED);
+                    break;
+                default:
+                    callback(null, Characteristic.LockCurrentState.UNKNOWN);
+                    break;
+            }
+        })
+        .on('set', function(value, callback) {
+            switch (value) {
+                case Characteristic.LockTargetState.SECURED:
+                    platform.UpdateWinkProperty_withFeedback(that, callback, "locked", true);
+                    break;
+                case Characteristic.LockTargetState.UNSECURED:
+                    platform.UpdateWinkProperty_withFeedback(that, callback, "locked", false);
+                    break;
+            }
+        });
+
+    //Track the Battery Level
+    if (that.device.last_reading.battery !== undefined) {
+        this.addService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
+            .on('get', function(callback) {
+                callback(null, Math.floor(that.device.last_reading.battery * 100));
+            });
+
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
+            .on('get', function(callback) {
+                if (that.device.last_reading.battery < 0.25)
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+                else
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+            });
+
+        this.getService(Service.BatteryService)
+            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+    }
+    //End Battery Level Tracking
+
 }
 
 WinkLockAccessory.prototype = {
-  loadData: function() {
-    this.getService(Service.LockMechanism)
-      .getCharacteristic(Characteristic.LockCurrentState)
-      .getValue();
-    this.getService(Service.LockMechanism)
-      .getCharacteristic(Characteristic.LockTargetState)
-      .getValue();
-  },
-  
-  getServices: function() {
-    return this.services;
-  },
-  
-  handleResponse: function(res) {
-    if (!res) {
-      return Error("No response from Wink");
-    } else if (res.errors && res.errors.length > 0) {
-      return res.errors[0];
-    } else if (res.data) {
-      this.device = res.data;
-      this.loadData();
+    loadData: function() {
+        this.getService(Service.LockMechanism)
+            .getCharacteristic(Characteristic.LockCurrentState)
+            .getValue();
+        this.getService(Service.LockMechanism)
+            .getCharacteristic(Characteristic.LockTargetState)
+            .getValue();
+        if (this.device.last_reading.battery !== undefined) {
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.BatteryLevel)
+                .getValue();
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.StatusLowBattery)
+                .getValue();
+        }
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
     }
-  }
 }
 module.exports = WinkLockAccessory;

--- a/accessories/locks.js
+++ b/accessories/locks.js
@@ -4,40 +4,33 @@ var inherits = require('util').inherits;
 /*
  *   Generic Accessory
  */
-var Service, Characteristic, Accessory, uuid;
+var WinkAccessory, Accessory, Service, Characteristic, uuid;
 
 /*
  *   Lock Accessory
  */
 
-function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-    // Common Base Items
-    this.device = device;
-    this.name = device.name;
-    this.log = platform.log;
-    this.platform = platform;
-    this.deviceGroup = 'locks';
-    this.deviceId = this.device.lock_id;
+module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
+{
+    if (oWinkAccessory) {
+        WinkAccessory = oWinkAccessory;
+        Accessory = oAccessory;
+        Service = oService;
+        Characteristic = oCharacteristic;
+        uuid = ouuid;
 
-    Service = oService;
-    Characteristic = oCharacteristic;
-    Accessory = oAccessory;
-    uuid = ouuid;
+        inherits(WinkLockAccessory, WinkAccessory);
+        WinkLockAccessory.prototype.loadData = loadData;
+        WinkLockAccessory.prototype.deviceGroup = 'locks';
+    }
+    return WinkLockAccessory;
+};
+module.exports.WinkLockAccessory = WinkLockAccessory;
 
-    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
-    var id = uuid.generate(idKey);
-    Accessory.call(this, this.name, id);
-    this.uuid_base = id;
+function WinkLockAccessory(platform, device) {
+    WinkAccessory.call(this, platform, device, device.lock_id);
 
-    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
-
-    //this.log(idKey+' '+ JSON.stringify(device));
     var that = this;
-    // set some basic properties (these values are arbitrary and setting them is optional)
-    this
-        .getService(Service.AccessoryInformation)
-        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-        .setCharacteristic(Characteristic.Model, this.device.model_name);
 
     //Items specific to Door Locks:
     this
@@ -76,10 +69,10 @@ function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccesso
         .on('set', function(value, callback) {
             switch (value) {
                 case Characteristic.LockTargetState.SECURED:
-                    platform.UpdateWinkProperty_withFeedback(that, callback, "locked", true);
+                    that.updatePropertyWithFeedback(callback, "locked", true);
                     break;
                 case Characteristic.LockTargetState.UNSECURED:
-                    platform.UpdateWinkProperty_withFeedback(that, callback, "locked", false);
+                    that.updatePropertyWithFeedback(callback, "locked", false);
                     break;
             }
         });
@@ -106,39 +99,22 @@ function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccesso
     }
     //End Battery Level Tracking
 
+    this.loadData();
 }
 
-WinkLockAccessory.prototype = {
-    loadData: function() {
-        this.getService(Service.LockMechanism)
-            .getCharacteristic(Characteristic.LockCurrentState)
+var loadData = function() {
+    this.getService(Service.LockMechanism)
+        .getCharacteristic(Characteristic.LockCurrentState)
+        .getValue();
+    this.getService(Service.LockMechanism)
+        .getCharacteristic(Characteristic.LockTargetState)
+        .getValue();
+    if (this.device.last_reading.battery !== undefined) {
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
             .getValue();
-        this.getService(Service.LockMechanism)
-            .getCharacteristic(Characteristic.LockTargetState)
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
             .getValue();
-        if (this.device.last_reading.battery !== undefined) {
-            this.getService(Service.BatteryService)
-                .getCharacteristic(Characteristic.BatteryLevel)
-                .getValue();
-            this.getService(Service.BatteryService)
-                .getCharacteristic(Characteristic.StatusLowBattery)
-                .getValue();
-        }
-    },
-
-    getServices: function() {
-        return this.services;
-    },
-
-    handleResponse: function(res) {
-        if (!res) {
-            return Error("No response from Wink");
-        } else if (res.errors && res.errors.length > 0) {
-            return res.errors[0];
-        } else if (res.data) {
-            this.device = res.data;
-            this.loadData();
-        }
     }
-}
-module.exports = WinkLockAccessory;
+};

--- a/accessories/locks.js
+++ b/accessories/locks.js
@@ -10,111 +10,110 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Lock Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkLockAccessory, WinkAccessory);
-        WinkLockAccessory.prototype.loadData = loadData;
-        WinkLockAccessory.prototype.deviceGroup = 'locks';
-    }
-    return WinkLockAccessory;
+		inherits(WinkLockAccessory, WinkAccessory);
+		WinkLockAccessory.prototype.loadData = loadData;
+		WinkLockAccessory.prototype.deviceGroup = 'locks';
+	}
+	return WinkLockAccessory;
 };
 module.exports.WinkLockAccessory = WinkLockAccessory;
 
 function WinkLockAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.lock_id);
+	WinkAccessory.call(this, platform, device, device.lock_id);
 
-    var that = this;
+	var that = this;
 
-    //Items specific to Door Locks:
-    this
-        .addService(Service.LockMechanism)
-        .getCharacteristic(Characteristic.LockCurrentState)
-        .on('get', function(callback) {
-            switch (that.device.last_reading.locked) {
-                case true:
-                    callback(null, Characteristic.LockCurrentState.SECURED);
-                    break;
-                case false:
-                    callback(null, Characteristic.LockCurrentState.UNSECURED);
-                    break;
-                default:
-                    callback(null, Characteristic.LockCurrentState.UNKNOWN);
-                    break;
-            }
-        });
+	//Items specific to Door Locks:
+	this
+		.addService(Service.LockMechanism)
+		.getCharacteristic(Characteristic.LockCurrentState)
+		.on('get', function (callback) {
+			switch (that.device.last_reading.locked) {
+				case true:
+					callback(null, Characteristic.LockCurrentState.SECURED);
+					break;
+				case false:
+					callback(null, Characteristic.LockCurrentState.UNSECURED);
+					break;
+				default:
+					callback(null, Characteristic.LockCurrentState.UNKNOWN);
+					break;
+			}
+		});
 
-    this
-        .getService(Service.LockMechanism)
-        .getCharacteristic(Characteristic.LockTargetState)
-        .on('get', function(callback) {
-            switch (that.device.desired_state.locked) {
-                case true:
-                    callback(null, Characteristic.LockCurrentState.SECURED);
-                    break;
-                case false:
-                    callback(null, Characteristic.LockCurrentState.UNSECURED);
-                    break;
-                default:
-                    callback(null, Characteristic.LockCurrentState.UNKNOWN);
-                    break;
-            }
-        })
-        .on('set', function(value, callback) {
-            switch (value) {
-                case Characteristic.LockTargetState.SECURED:
-                    that.updatePropertyWithFeedback(callback, "locked", true);
-                    break;
-                case Characteristic.LockTargetState.UNSECURED:
-                    that.updatePropertyWithFeedback(callback, "locked", false);
-                    break;
-            }
-        });
+	this
+		.getService(Service.LockMechanism)
+		.getCharacteristic(Characteristic.LockTargetState)
+		.on('get', function (callback) {
+			switch (that.device.desired_state.locked) {
+				case true:
+					callback(null, Characteristic.LockCurrentState.SECURED);
+					break;
+				case false:
+					callback(null, Characteristic.LockCurrentState.UNSECURED);
+					break;
+				default:
+					callback(null, Characteristic.LockCurrentState.UNKNOWN);
+					break;
+			}
+		})
+		.on('set', function (value, callback) {
+			switch (value) {
+				case Characteristic.LockTargetState.SECURED:
+					that.updatePropertyWithFeedback(callback, "locked", true);
+					break;
+				case Characteristic.LockTargetState.UNSECURED:
+					that.updatePropertyWithFeedback(callback, "locked", false);
+					break;
+			}
+		});
 
-    //Track the Battery Level
-    if (that.device.last_reading.battery !== undefined) {
-        this.addService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .on('get', function(callback) {
-                callback(null, Math.floor(that.device.last_reading.battery * 100));
-            });
+	//Track the Battery Level
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.battery * 100));
+			});
 
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .on('get', function(callback) {
-                if (that.device.last_reading.battery < 0.25)
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-                else
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-            });
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.battery < 0.25)
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
 
-        this.getService(Service.BatteryService)
-            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
-    }
-    //End Battery Level Tracking
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
+	//End Battery Level Tracking
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    this.getService(Service.LockMechanism)
-        .getCharacteristic(Characteristic.LockCurrentState)
-        .getValue();
-    this.getService(Service.LockMechanism)
-        .getCharacteristic(Characteristic.LockTargetState)
-        .getValue();
-    if (this.device.last_reading.battery !== undefined) {
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .getValue();
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .getValue();
-    }
+var loadData = function () {
+	this.getService(Service.LockMechanism)
+		.getCharacteristic(Characteristic.LockCurrentState)
+		.getValue();
+	this.getService(Service.LockMechanism)
+		.getCharacteristic(Characteristic.LockTargetState)
+		.getValue();
+	if (this.device.last_reading.battery !== undefined) {
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.getValue();
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.getValue();
+	}
 };

--- a/accessories/outlets.js
+++ b/accessories/outlets.js
@@ -1,0 +1,78 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Outlet Accessory (Sub Accessory of the Powerstrip)
+ */
+
+function WinkOutletAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+  // Common Base Items
+  this.device = device;
+  this.name = device.name;
+  this.log = platform.log;
+  this.platform = platform;
+  this.deviceGroup='outlets';
+  this.deviceId=this.device.outlet_id;
+
+ Service = oService;
+ Characteristic = oCharacteristic;
+ Accessory = oAccessory;
+ uuid = ouuid;
+
+  var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+  var id = uuid.generate(idKey);
+  Accessory.call(this, this.name, id);
+  this.uuid_base = id;
+
+  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+  //this.log(idKey+' '+ JSON.stringify(device));
+  var that = this;
+  // set some basic properties (these values are arbitrary and setting them is optional)
+  this
+      .getService(Service.AccessoryInformation)
+      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+      .setCharacteristic(Characteristic.Model, this.device.model_name)
+      .setCharacteristic(Characteristic.Name, this.device.name);
+      
+  //If consumption is defined then we will treat this as an Outlet.
+  //This covers the Outlink Wall Plug.
+  this
+   .addService(Service.Outlet)
+   .getCharacteristic(Characteristic.On)
+   .on('get', function(callback) {
+     callback(null, that.device.last_reading.powered);
+   })
+   .on('set', function(value, callback) {
+     platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+   });
+  this
+   .getService(Service.Outlet)
+   .setCharacteristic(Characteristic.OutletInUse, false); 
+}
+
+WinkOutletAccessory.prototype = {
+  loadData: function() {
+    this.getService(Service.Outlet)
+      .getCharacteristic(Characteristic.On)
+      .getValue();
+  },
+  
+  getServices: function() {
+    return this.services;
+  },
+  
+  handleResponse: function(res) {
+    if (!res) {
+      return Error("No response from Wink");
+    } else if (res.errors && res.errors.length > 0) {
+      return res.errors[0];
+    } else if (res.data) {
+      this.device = res.data;
+      this.loadData();
+    }
+  }
+}
+module.exports = WinkOutletAccessory;

--- a/accessories/outlets.js
+++ b/accessories/outlets.js
@@ -7,48 +7,47 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Outlet Accessory (Sub Accessory of the Powerstrip)
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkOutletAccessory, WinkAccessory);
-        WinkOutletAccessory.prototype.loadData = loadData;
-        WinkOutletAccessory.prototype.deviceGroup = 'outlets';
-    }
-    return WinkOutletAccessory;
+		inherits(WinkOutletAccessory, WinkAccessory);
+		WinkOutletAccessory.prototype.loadData = loadData;
+		WinkOutletAccessory.prototype.deviceGroup = 'outlets';
+	}
+	return WinkOutletAccessory;
 };
 module.exports.WinkOutletAccessory = WinkOutletAccessory;
 
 function WinkOutletAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.outlet_id);
+	WinkAccessory.call(this, platform, device, device.outlet_id);
 
-    var that = this;
+	var that = this;
 
-  //If consumption is defined then we will treat this as an Outlet.
-  //This covers the Outlink Wall Plug.
-  this
-   .addService(Service.Outlet)
-   .getCharacteristic(Characteristic.On)
-   .on('get', function(callback) {
-     callback(null, that.device.last_reading.powered);
-   })
-   .on('set', function(value, callback) {
-     that.updatePropertyWithoutFeedback(callback, "powered", value);
-   });
-  this
-   .getService(Service.Outlet)
-   .setCharacteristic(Characteristic.OutletInUse, false);
+	//If consumption is defined then we will treat this as an Outlet.
+	//This covers the Outlink Wall Plug.
+	this
+		.addService(Service.Outlet)
+		.getCharacteristic(Characteristic.On)
+		.on('get', function (callback) {
+			callback(null, that.device.last_reading.powered);
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, "powered", value);
+		});
+	this
+		.getService(Service.Outlet)
+		.setCharacteristic(Characteristic.OutletInUse, false);
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    this.getService(Service.Outlet)
-      .getCharacteristic(Characteristic.On)
-      .getValue();
+var loadData = function () {
+	this.getService(Service.Outlet)
+		.getCharacteristic(Characteristic.On)
+		.getValue();
 };

--- a/accessories/outlets.js
+++ b/accessories/outlets.js
@@ -1,42 +1,34 @@
 var wink = require('wink-js');
 var inherits = require('util').inherits;
 
-var Service, Characteristic, Accessory, uuid;
+var WinkAccessory, Accessory, Service, Characteristic, uuid;
 
 /*
  *   Outlet Accessory (Sub Accessory of the Powerstrip)
  */
 
-function WinkOutletAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-  // Common Base Items
-  this.device = device;
-  this.name = device.name;
-  this.log = platform.log;
-  this.platform = platform;
-  this.deviceGroup='outlets';
-  this.deviceId=this.device.outlet_id;
+module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
+{
+    if (oWinkAccessory) {
+        WinkAccessory = oWinkAccessory;
+        Accessory = oAccessory;
+        Service = oService;
+        Characteristic = oCharacteristic;
+        uuid = ouuid;
 
- Service = oService;
- Characteristic = oCharacteristic;
- Accessory = oAccessory;
- uuid = ouuid;
+        inherits(WinkOutletAccessory, WinkAccessory);
+        WinkOutletAccessory.prototype.loadData = loadData;
+        WinkOutletAccessory.prototype.deviceGroup = 'outlets';
+    }
+    return WinkOutletAccessory;
+};
+module.exports.WinkOutletAccessory = WinkOutletAccessory;
 
-  var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
-  var id = uuid.generate(idKey);
-  Accessory.call(this, this.name, id);
-  this.uuid_base = id;
+function WinkOutletAccessory(platform, device) {
+    WinkAccessory.call(this, platform, device, device.outlet_id);
 
-  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+    var that = this;
 
-  //this.log(idKey+' '+ JSON.stringify(device));
-  var that = this;
-  // set some basic properties (these values are arbitrary and setting them is optional)
-  this
-      .getService(Service.AccessoryInformation)
-      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-      .setCharacteristic(Characteristic.Model, this.device.model_name)
-      .setCharacteristic(Characteristic.Name, this.device.name);
-      
   //If consumption is defined then we will treat this as an Outlet.
   //This covers the Outlink Wall Plug.
   this
@@ -46,33 +38,17 @@ function WinkOutletAccessory(platform, device, oService, oCharacteristic, oAcces
      callback(null, that.device.last_reading.powered);
    })
    .on('set', function(value, callback) {
-     platform.UpdateWinkProperty_noFeedback(that, callback, "powered", value);
+     that.updatePropertyWithoutFeedback(callback, "powered", value);
    });
   this
    .getService(Service.Outlet)
-   .setCharacteristic(Characteristic.OutletInUse, false); 
+   .setCharacteristic(Characteristic.OutletInUse, false);
+
+    this.loadData();
 }
 
-WinkOutletAccessory.prototype = {
-  loadData: function() {
+var loadData = function() {
     this.getService(Service.Outlet)
       .getCharacteristic(Characteristic.On)
       .getValue();
-  },
-  
-  getServices: function() {
-    return this.services;
-  },
-  
-  handleResponse: function(res) {
-    if (!res) {
-      return Error("No response from Wink");
-    } else if (res.errors && res.errors.length > 0) {
-      return res.errors[0];
-    } else if (res.data) {
-      this.device = res.data;
-      this.loadData();
-    }
-  }
-}
-module.exports = WinkOutletAccessory;
+};

--- a/accessories/propane_tanks.js
+++ b/accessories/propane_tanks.js
@@ -1,0 +1,87 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Thermostat Accessory
+ */
+
+function WinkPropaneTankAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'propane_tanks';
+    this.deviceId = this.device.propane_tank_id;
+
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
+
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
+
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
+    this
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name);
+
+    //The level of the propane tank is being expressed like a Battery because there isn't any other kind of tank level available in HomeKit.
+    if (that.device.last_reading.battery !== undefined) {
+        this.addService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
+            .on('get', function(callback) {
+                callback(null, Math.floor(that.device.last_reading.remaining * 100));
+            });
+
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
+            .on('get', function(callback) {
+                if ((that.device.last_reading.battery < 0.25)||(that.device.last_reading.remaining < 0.25)) //Indicate Low Battery for the battery AND the propane level
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+                else
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+            });
+
+        this.getService(Service.BatteryService)
+            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+    }
+    //End Battery Level Tracking   
+}
+
+WinkPropaneTankAccessory.prototype = {
+    loadData: function() {
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.BatteryLevel)
+                .getValue();
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.StatusLowBattery)
+                .getValue();
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
+    }
+}
+module.exports = WinkPropaneTankAccessory;

--- a/accessories/propane_tanks.js
+++ b/accessories/propane_tanks.js
@@ -1,4 +1,3 @@
-var wink = require('wink-js');
 var inherits = require('util').inherits;
 
 var WinkAccessory, Accessory, Service, Characteristic, uuid;

--- a/accessories/propane_tanks.js
+++ b/accessories/propane_tanks.js
@@ -7,58 +7,57 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Propane Tank Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkPropaneTankAccessory, WinkAccessory);
-        WinkPropaneTankAccessory.prototype.loadData = loadData;
-        WinkPropaneTankAccessory.prototype.deviceGroup = 'propane_tanks';
-    }
-    return WinkPropaneTankAccessory;
+		inherits(WinkPropaneTankAccessory, WinkAccessory);
+		WinkPropaneTankAccessory.prototype.loadData = loadData;
+		WinkPropaneTankAccessory.prototype.deviceGroup = 'propane_tanks';
+	}
+	return WinkPropaneTankAccessory;
 };
 module.exports.WinkPropaneTankAccessory = WinkPropaneTankAccessory;
 
 function WinkPropaneTankAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.propane_tank_id);
+	WinkAccessory.call(this, platform, device, device.propane_tank_id);
 
-    var that = this;
+	var that = this;
 
-    //The level of the propane tank is being expressed like a Battery because there isn't any other kind of tank level available in HomeKit.
-    if (that.device.last_reading.battery !== undefined) {
-        this.addService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .on('get', function(callback) {
-                callback(null, Math.floor(that.device.last_reading.remaining * 100));
-            });
+	//The level of the propane tank is being expressed like a Battery because there isn't any other kind of tank level available in HomeKit.
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.remaining * 100));
+			});
 
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .on('get', function(callback) {
-                if (that.device.last_reading.remaining < 0.25) //Indicate Low Battery for the battery AND the propane level
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-                else
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-            });
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.remaining < 0.25) //Indicate Low Battery for the battery AND the propane level
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
 
-        this.getService(Service.BatteryService)
-            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
-    }
-    //End Battery Level Tracking
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
+	//End Battery Level Tracking
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .getValue();
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .getValue();
+var loadData = function () {
+	this.getService(Service.BatteryService)
+		.getCharacteristic(Characteristic.BatteryLevel)
+		.getValue();
+	this.getService(Service.BatteryService)
+		.getCharacteristic(Characteristic.StatusLowBattery)
+		.getValue();
 };

--- a/accessories/sensor_pods.js
+++ b/accessories/sensor_pods.js
@@ -1,0 +1,184 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+/*
+ *   Generic Accessory
+ */
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Lock Accessory
+ */
+
+function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'sensor_pods';
+    this.deviceId = this.device.sensor_pod_id;
+
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
+
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
+
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
+    this
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name);
+
+
+    //brightness <- This is change in brightness. No similar HomeKit Service.
+    //external_power
+    //loudness 0/1
+    //vibration 0/1
+
+    //opened true/false
+    //tamper_detected true/false
+
+    //Motion detector with PIR
+    if (that.device.last_reading.motion !== undefined) {
+        this
+            .addService(Service.MotionSensor)
+            .getCharacteristic(Characteristic.MotionDetected)
+            .on('get', function(callback) {
+                callback(null, that.device.last_reading.motion);
+            });
+        if (that.device.last_reading.tamper_detected !== undefined)
+            this
+            .getService(Service.MotionSensor)
+            .getCharacteristic(Characteristic.StatusTampered)
+            .on('get', function(callback) {
+                callback(null, that.device.last_reading.tamper_detected);
+            });
+    }
+
+    //Humidity Detection
+    if (that.device.last_reading.humidity !== undefined)
+        this
+        .addService(Service.HumiditySensor)
+        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.humidity);
+        });
+
+    //Temperature Detection
+    if (that.device.last_reading.temperature !== undefined)
+        this
+        .addService(Service.TemperatureSensor)
+        .getCharacteristic(Characteristic.CurrentTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.temperature);
+        });
+
+    //Open/Close Sensor
+    if (that.device.last_reading.opened !== undefined)
+        this
+        .addService(Service.Door)
+        .getCharacteristic(Characteristic.CurrentPosition)
+        .on('get', function(callback) {
+            if (that.device.last_reading.opened)
+                callback(null, 100);
+            else
+                callback(null, 0);
+        });
+
+
+    //Track the Battery Level
+    if (that.device.last_reading.battery !== undefined) {
+        this.addService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
+            .on('get', function(callback) {
+                callback(null, Math.floor(that.device.last_reading.battery * 100));
+            });
+
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
+            .on('get', function(callback) {
+                if (that.device.last_reading.battery < 0.25)
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+                else
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+            });
+
+        this.getService(Service.BatteryService)
+            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+    }
+    //End Battery Level Tracking
+
+}
+
+WinkLockAccessory.prototype = {
+    loadData: function() {
+        if (this.device.last_reading.battery !== undefined) {
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.BatteryLevel)
+                .getValue();
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.StatusLowBattery)
+                .getValue();
+        }
+
+        //Motion detector with PIR
+        if (this.device.last_reading.motion !== undefined) {
+            this
+                .getService(Service.MotionSensor)
+                .getCharacteristic(Characteristic.MotionDetected)
+                .getValue();
+            if (this.device.last_reading.tamper_detected !== undefined)
+                this
+                .getService(Service.MotionSensor)
+                .getCharacteristic(Characteristic.StatusTampered)
+                .getValue();
+        }
+
+        //Humidity Detection
+        if (this.device.last_reading.humidity !== undefined)
+            this
+            .getService(Service.HumiditySensor)
+            .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+            .getValue();
+
+        //Temperature Detection
+        if (this.device.last_reading.temperature !== undefined)
+            this
+            .getService(Service.TemperatureSensor)
+            .getCharacteristic(Characteristic.CurrentTemperature)
+            .getValue();
+
+        //Open/Close Sensor
+        if (this.device.last_reading.opened !== undefined)
+            this
+            .getService(Service.Door)
+            .getCharacteristic(Characteristic.CurrentPosition)
+            .getValue();
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
+    }
+}
+module.exports = WinkLockAccessory;

--- a/accessories/sensor_pods.js
+++ b/accessories/sensor_pods.js
@@ -1,4 +1,3 @@
-var wink = require('wink-js');
 var inherits = require('util').inherits;
 
 /*

--- a/accessories/sensor_pods.js
+++ b/accessories/sensor_pods.js
@@ -4,41 +4,33 @@ var inherits = require('util').inherits;
 /*
  *   Generic Accessory
  */
-var Service, Characteristic, Accessory, uuid;
+var WinkAccessory, Accessory, Service, Characteristic, uuid;
 
 /*
- *   Lock Accessory
+ *   Sensor Pod Accessory
  */
 
-function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
-    // Common Base Items
-    this.device = device;
-    this.name = device.name;
-    this.log = platform.log;
-    this.platform = platform;
-    this.deviceGroup = 'sensor_pods';
-    this.deviceId = this.device.sensor_pod_id;
+module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
+{
+    if (oWinkAccessory) {
+        WinkAccessory = oWinkAccessory;
+        Accessory = oAccessory;
+        Service = oService;
+        Characteristic = oCharacteristic;
+        uuid = ouuid;
 
-    Service = oService;
-    Characteristic = oCharacteristic;
-    Accessory = oAccessory;
-    uuid = ouuid;
+        inherits(WinkSensorAccessory, WinkAccessory);
+        WinkSensorAccessory.prototype.loadData = loadData;
+        WinkSensorAccessory.prototype.deviceGroup = 'sensor_pods';
+    }
+    return WinkSensorAccessory;
+};
+module.exports.WinkSensorAccessory = WinkSensorAccessory;
 
-    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
-    var id = uuid.generate(idKey);
-    Accessory.call(this, this.name, id);
-    this.uuid_base = id;
+function WinkSensorAccessory(platform, device) {
+    WinkAccessory.call(this, platform, device, device.sensor_pod_id);
 
-    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
-
-    //this.log(idKey+' '+ JSON.stringify(device));
     var that = this;
-    // set some basic properties (these values are arbitrary and setting them is optional)
-    this
-        .getService(Service.AccessoryInformation)
-        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-        .setCharacteristic(Characteristic.Model, this.device.model_name);
-
 
     //brightness <- This is change in brightness. No similar HomeKit Service.
     //external_power
@@ -134,67 +126,50 @@ function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccesso
     }
     //End Battery Level Tracking
 
+    this.loadData();
 }
 
-WinkLockAccessory.prototype = {
-    loadData: function() {
-        if (this.device.last_reading.battery !== undefined) {
-            this.getService(Service.BatteryService)
-                .getCharacteristic(Characteristic.BatteryLevel)
-                .getValue();
-            this.getService(Service.BatteryService)
-                .getCharacteristic(Characteristic.StatusLowBattery)
-                .getValue();
-        }
-
-        //Motion detector with PIR
-        if (this.device.last_reading.motion !== undefined) {
-            this
-                .getService(Service.MotionSensor)
-                .getCharacteristic(Characteristic.MotionDetected)
-                .getValue();
-            if (this.device.last_reading.tamper_detected !== undefined)
-                this
-                .getService(Service.MotionSensor)
-                .getCharacteristic(Characteristic.StatusTampered)
-                .getValue();
-        }
-
-        //Humidity Detection
-        if (this.device.last_reading.humidity !== undefined)
-            this
-            .getService(Service.HumiditySensor)
-            .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+var loadData = function() {
+    if (this.device.last_reading.battery !== undefined) {
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
             .getValue();
-
-        //Temperature Detection
-        if (this.device.last_reading.temperature !== undefined)
-            this
-            .getService(Service.TemperatureSensor)
-            .getCharacteristic(Characteristic.CurrentTemperature)
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
             .getValue();
-
-        //Open/Close Sensor
-        if (this.device.last_reading.opened !== undefined)
-            this
-            .getService(Service.Door)
-            .getCharacteristic(Characteristic.CurrentPosition)
-            .getValue();
-    },
-
-    getServices: function() {
-        return this.services;
-    },
-
-    handleResponse: function(res) {
-        if (!res) {
-            return Error("No response from Wink");
-        } else if (res.errors && res.errors.length > 0) {
-            return res.errors[0];
-        } else if (res.data) {
-            this.device = res.data;
-            this.loadData();
-        }
     }
-}
-module.exports = WinkLockAccessory;
+
+    //Motion detector with PIR
+    if (this.device.last_reading.motion !== undefined) {
+        this
+            .getService(Service.MotionSensor)
+            .getCharacteristic(Characteristic.MotionDetected)
+            .getValue();
+        if (this.device.last_reading.tamper_detected !== undefined)
+            this
+            .getService(Service.MotionSensor)
+            .getCharacteristic(Characteristic.StatusTampered)
+            .getValue();
+    }
+
+    //Humidity Detection
+    if (this.device.last_reading.humidity !== undefined)
+        this
+        .getService(Service.HumiditySensor)
+        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+        .getValue();
+
+    //Temperature Detection
+    if (this.device.last_reading.temperature !== undefined)
+        this
+        .getService(Service.TemperatureSensor)
+        .getCharacteristic(Characteristic.CurrentTemperature)
+        .getValue();
+
+    //Open/Close Sensor
+    if (this.device.last_reading.opened !== undefined)
+        this
+        .getService(Service.Door)
+        .getCharacteristic(Characteristic.CurrentPosition)
+        .getValue();
+};

--- a/accessories/sensor_pods.js
+++ b/accessories/sensor_pods.js
@@ -44,11 +44,27 @@ function WinkLockAccessory(platform, device, oService, oCharacteristic, oAccesso
     //external_power
     //loudness 0/1
     //vibration 0/1
-
-    //opened true/false
     //tamper_detected true/false
 
-    //Motion detector with PIR
+
+  //Occupancy
+    if (that.device.last_reading.occupied !== undefined) {
+        this
+            .addService(Service.OccupancySensor)
+            .getCharacteristic(Characteristic.OccupancyDetected)
+            .on('get', function(callback) {
+                callback(null, that.device.last_reading.occupied);
+            });
+        if (that.device.last_reading.tamper_detected !== undefined)
+            this
+            .getService(Service.OccupancySensor)
+            .getCharacteristic(Characteristic.StatusTampered)
+            .on('get', function(callback) {
+                callback(null, that.device.last_reading.tamper_detected);
+            });
+    }
+
+  //Motion detector with PIR
     if (that.device.last_reading.motion !== undefined) {
         this
             .addService(Service.MotionSensor)

--- a/accessories/sensor_pods.js
+++ b/accessories/sensor_pods.js
@@ -10,166 +10,165 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Sensor Pod Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkSensorAccessory, WinkAccessory);
-        WinkSensorAccessory.prototype.loadData = loadData;
-        WinkSensorAccessory.prototype.deviceGroup = 'sensor_pods';
-    }
-    return WinkSensorAccessory;
+		inherits(WinkSensorAccessory, WinkAccessory);
+		WinkSensorAccessory.prototype.loadData = loadData;
+		WinkSensorAccessory.prototype.deviceGroup = 'sensor_pods';
+	}
+	return WinkSensorAccessory;
 };
 module.exports.WinkSensorAccessory = WinkSensorAccessory;
 
 function WinkSensorAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.sensor_pod_id);
+	WinkAccessory.call(this, platform, device, device.sensor_pod_id);
 
-    var that = this;
+	var that = this;
 
-    //brightness <- This is change in brightness. No similar HomeKit Service.
-    //external_power
-    //loudness 0/1
-    //vibration 0/1
-    //tamper_detected true/false
-
-
-  //Occupancy
-    if (that.device.last_reading.occupied !== undefined) {
-        this
-            .addService(Service.OccupancySensor)
-            .getCharacteristic(Characteristic.OccupancyDetected)
-            .on('get', function(callback) {
-                callback(null, that.device.last_reading.occupied);
-            });
-        if (that.device.last_reading.tamper_detected !== undefined)
-            this
-            .getService(Service.OccupancySensor)
-            .getCharacteristic(Characteristic.StatusTampered)
-            .on('get', function(callback) {
-                callback(null, that.device.last_reading.tamper_detected);
-            });
-    }
-
-  //Motion detector with PIR
-    if (that.device.last_reading.motion !== undefined) {
-        this
-            .addService(Service.MotionSensor)
-            .getCharacteristic(Characteristic.MotionDetected)
-            .on('get', function(callback) {
-                callback(null, that.device.last_reading.motion);
-            });
-        if (that.device.last_reading.tamper_detected !== undefined)
-            this
-            .getService(Service.MotionSensor)
-            .getCharacteristic(Characteristic.StatusTampered)
-            .on('get', function(callback) {
-                callback(null, that.device.last_reading.tamper_detected);
-            });
-    }
-
-    //Humidity Detection
-    if (that.device.last_reading.humidity !== undefined)
-        this
-        .addService(Service.HumiditySensor)
-        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.humidity);
-        });
-
-    //Temperature Detection
-    if (that.device.last_reading.temperature !== undefined)
-        this
-        .addService(Service.TemperatureSensor)
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.temperature);
-        });
-
-    //Open/Close Sensor
-    if (that.device.last_reading.opened !== undefined)
-        this
-        .addService(Service.Door)
-        .getCharacteristic(Characteristic.CurrentPosition)
-        .on('get', function(callback) {
-            if (that.device.last_reading.opened)
-                callback(null, 100);
-            else
-                callback(null, 0);
-        });
+	//brightness <- This is change in brightness. No similar HomeKit Service.
+	//external_power
+	//loudness 0/1
+	//vibration 0/1
+	//tamper_detected true/false
 
 
-    //Track the Battery Level
-    if (that.device.last_reading.battery !== undefined) {
-        this.addService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .on('get', function(callback) {
-                callback(null, Math.floor(that.device.last_reading.battery * 100));
-            });
+	//Occupancy
+	if (that.device.last_reading.occupied !== undefined) {
+		this
+			.addService(Service.OccupancySensor)
+			.getCharacteristic(Characteristic.OccupancyDetected)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.occupied);
+			});
+		if (that.device.last_reading.tamper_detected !== undefined)
+			this
+				.getService(Service.OccupancySensor)
+				.getCharacteristic(Characteristic.StatusTampered)
+				.on('get', function (callback) {
+					callback(null, that.device.last_reading.tamper_detected);
+				});
+	}
 
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .on('get', function(callback) {
-                if (that.device.last_reading.battery < 0.25)
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-                else
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-            });
+	//Motion detector with PIR
+	if (that.device.last_reading.motion !== undefined) {
+		this
+			.addService(Service.MotionSensor)
+			.getCharacteristic(Characteristic.MotionDetected)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.motion);
+			});
+		if (that.device.last_reading.tamper_detected !== undefined)
+			this
+				.getService(Service.MotionSensor)
+				.getCharacteristic(Characteristic.StatusTampered)
+				.on('get', function (callback) {
+					callback(null, that.device.last_reading.tamper_detected);
+				});
+	}
 
-        this.getService(Service.BatteryService)
-            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
-    }
-    //End Battery Level Tracking
+	//Humidity Detection
+	if (that.device.last_reading.humidity !== undefined)
+		this
+			.addService(Service.HumiditySensor)
+			.getCharacteristic(Characteristic.CurrentRelativeHumidity)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.humidity);
+			});
 
-    this.loadData();
+	//Temperature Detection
+	if (that.device.last_reading.temperature !== undefined)
+		this
+			.addService(Service.TemperatureSensor)
+			.getCharacteristic(Characteristic.CurrentTemperature)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.temperature);
+			});
+
+	//Open/Close Sensor
+	if (that.device.last_reading.opened !== undefined)
+		this
+			.addService(Service.Door)
+			.getCharacteristic(Characteristic.CurrentPosition)
+			.on('get', function (callback) {
+				if (that.device.last_reading.opened)
+					callback(null, 100);
+				else
+					callback(null, 0);
+			});
+
+
+	//Track the Battery Level
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.battery * 100));
+			});
+
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.battery < 0.25)
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
+
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
+	//End Battery Level Tracking
+
+	this.loadData();
 }
 
-var loadData = function() {
-    if (this.device.last_reading.battery !== undefined) {
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .getValue();
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .getValue();
-    }
+var loadData = function () {
+	if (this.device.last_reading.battery !== undefined) {
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.getValue();
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.getValue();
+	}
 
-    //Motion detector with PIR
-    if (this.device.last_reading.motion !== undefined) {
-        this
-            .getService(Service.MotionSensor)
-            .getCharacteristic(Characteristic.MotionDetected)
-            .getValue();
-        if (this.device.last_reading.tamper_detected !== undefined)
-            this
-            .getService(Service.MotionSensor)
-            .getCharacteristic(Characteristic.StatusTampered)
-            .getValue();
-    }
+	//Motion detector with PIR
+	if (this.device.last_reading.motion !== undefined) {
+		this
+			.getService(Service.MotionSensor)
+			.getCharacteristic(Characteristic.MotionDetected)
+			.getValue();
+		if (this.device.last_reading.tamper_detected !== undefined)
+			this
+				.getService(Service.MotionSensor)
+				.getCharacteristic(Characteristic.StatusTampered)
+				.getValue();
+	}
 
-    //Humidity Detection
-    if (this.device.last_reading.humidity !== undefined)
-        this
-        .getService(Service.HumiditySensor)
-        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .getValue();
+	//Humidity Detection
+	if (this.device.last_reading.humidity !== undefined)
+		this
+			.getService(Service.HumiditySensor)
+			.getCharacteristic(Characteristic.CurrentRelativeHumidity)
+			.getValue();
 
-    //Temperature Detection
-    if (this.device.last_reading.temperature !== undefined)
-        this
-        .getService(Service.TemperatureSensor)
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .getValue();
+	//Temperature Detection
+	if (this.device.last_reading.temperature !== undefined)
+		this
+			.getService(Service.TemperatureSensor)
+			.getCharacteristic(Characteristic.CurrentTemperature)
+			.getValue();
 
-    //Open/Close Sensor
-    if (this.device.last_reading.opened !== undefined)
-        this
-        .getService(Service.Door)
-        .getCharacteristic(Characteristic.CurrentPosition)
-        .getValue();
+	//Open/Close Sensor
+	if (this.device.last_reading.opened !== undefined)
+		this
+			.getService(Service.Door)
+			.getCharacteristic(Characteristic.CurrentPosition)
+			.getValue();
 };

--- a/accessories/sirens.js
+++ b/accessories/sirens.js
@@ -1,0 +1,118 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var WinkAccessory, Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Binary Switch Accessory
+ */
+
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
+
+		inherits(WinkSirenAccessory, WinkAccessory);
+		WinkSirenAccessory.prototype.loadData = loadData;
+		WinkSirenAccessory.prototype.deviceGroup = 'sirens';
+	}
+	return WinkSirenAccessory;
+};
+module.exports.WinkSirenAccessory = WinkSirenAccessory;
+
+function WinkSirenAccessory(platform, device) {
+	WinkAccessory.call(this, platform, device, device.siren_id);
+
+	var that = this;
+
+	//Strobe as a light
+	this
+		.addService(Service.Lightbulb)
+		.setCharacteristic(Characteristic.Name, "Strobe");
+
+	this
+		.getService(Service.Lightbulb)
+		.getCharacteristic(Characteristic.On)
+		.on('get', function (callback) {
+			if (!that.device.last_reading.powered)
+				callback(null, false);
+			else if (that.device.last_reading.mode=='siren_only')
+				callback(null, false);
+			else
+				callback(null, true);
+		})
+
+		.on('set', function (value, callback) {
+			if (value) {
+				if (!that.device.last_reading.powered)
+					that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "strobe_only"]);
+				else if (that.device.last_reading.mode == 'siren_only')
+					that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "siren_and_strobe"]);
+				else
+					that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "strobe_only"]);
+			} else {
+				if (that.device.last_reading.powered)
+					that.updatePropertyWithoutFeedback(callback, "powered", false);
+				else if (that.device.last_reading.mode == "siren_and_strobe")
+					that.updatePropertyWithoutFeedback(callback, "mode", "siren_only");
+				else
+					that.updatePropertyWithoutFeedback(callback, "powered", false);
+			}
+		});
+
+			//Siren as a switch
+			this
+				.addService(Service.Switch)
+				.setCharacteristic(Characteristic.Name, "Siren");
+
+			this
+				.getService(Service.Switch)
+				.getCharacteristic(Characteristic.On)
+				.on('get', function (callback) {
+					if (!that.device.last_reading.powered)
+						callback(null, false);
+					else if (that.device.last_reading.mode=='strobe_only')
+						callback(null, false);
+					else
+						callback(null, true);
+				})
+
+				.on('set', function (value, callback) {
+					if (value) {
+						if (!that.device.last_reading.powered)
+							that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "siren_only"]);
+						else if (that.device.last_reading.mode == 'siren_only')
+							that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "siren_and_strobe"]);
+						else
+							that.updatePropertyWithoutFeedback(callback, ["powered", "mode"], [true, "siren_only"]);
+					} else {
+						if (that.device.last_reading.powered)
+							that.updatePropertyWithoutFeedback(callback, "powered", false);
+						else if (that.device.last_reading.mode == "siren_and_strobe")
+							that.updatePropertyWithoutFeedback(callback, "mode", "strobe_only");
+						else
+							that.updatePropertyWithoutFeedback(callback, "powered", false);
+					}
+				});
+
+	this.loadData();
+}
+
+var loadData = function () {
+	if (this.device.last_reading.consumption == undefined) {
+		this.getService(Service.Lightbulb)
+			.getCharacteristic(Characteristic.On)
+			.getValue();
+	} else {
+		this.getService(Service.Outlet)
+			.getCharacteristic(Characteristic.On)
+			.getValue();
+		this.getService(Service.Outlet)
+			.getCharacteristic(Characteristic.OutletInUse)
+			.getValue();
+
+	}
+};

--- a/accessories/smoke_detectors.js
+++ b/accessories/smoke_detectors.js
@@ -7,125 +7,124 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Smoke Detector Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkSmokeDetectorAccessory, WinkAccessory);
-        WinkSmokeDetectorAccessory.prototype.loadData = loadData;
-        WinkSmokeDetectorAccessory.prototype.deviceGroup = 'smoke_detectors';
-    }
-    return WinkSmokeDetectorAccessory;
+		inherits(WinkSmokeDetectorAccessory, WinkAccessory);
+		WinkSmokeDetectorAccessory.prototype.loadData = loadData;
+		WinkSmokeDetectorAccessory.prototype.deviceGroup = 'smoke_detectors';
+	}
+	return WinkSmokeDetectorAccessory;
 };
 module.exports.WinkSmokeDetectorAccessory = WinkSmokeDetectorAccessory;
 
 function WinkSmokeDetectorAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.smoke_detector_id);
+	WinkAccessory.call(this, platform, device, device.smoke_detector_id);
 
-    var that = this;
-      
-  //Items specific to Smoke Detectors:
-  if (this.device.last_reading.co_detected !== undefined) {
-    this.addService(Service.CarbonMonoxideSensor)  
-      .getCharacteristic(Characteristic.CarbonMonoxideDetected)
-      .on('get', function(callback) {
-        if (that.device.last_reading.co_detected)
-          callback(null, Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL);
-        else
-          callback(null, Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL);
-      });
-  if (this.device.last_reading.battery !== undefined)    
-    this.getService(Service.CarbonMonoxideSensor)  
-      .getCharacteristic(Characteristic.StatusLowBattery)
-      .on('get', function(callback) {
-        if (that.device.last_reading.battery<0.25)
-          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-        else
-          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-      });
-   }
-      
-  if (this.device.last_reading.smoke_detected !== undefined) {
-    this.addService(Service.SmokeSensor)  
-      .getCharacteristic(Characteristic.SmokeDetected)
-      .on('get', function(callback) {
-        if (that.device.last_reading.smoke_detected)
-          callback(null, Characteristic.SmokeDetected.SMOKE_DETECTED);
-        else
-          callback(null, Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
-      });
-  if (this.device.last_reading.battery !== undefined)    
-    this.getService(Service.SmokeSensor)  
-      .getCharacteristic(Characteristic.StatusLowBattery)
-      .on('get', function(callback) {
-        if (that.device.last_reading.battery<0.25)
-          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-        else
-          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-      });
-    }
-  
-  //Track the Battery Level
-  if (that.device.last_reading.battery !== undefined) {
-    this.addService(Service.BatteryService)  
-      .getCharacteristic(Characteristic.BatteryLevel)
-      .on('get', function(callback) {
-        callback(null, Math.floor(that.device.last_reading.battery*100));
-      });
+	var that = this;
 
-    this.getService(Service.BatteryService)  
-      .getCharacteristic(Characteristic.StatusLowBattery)
-      .on('get', function(callback) {
-        if (that.device.last_reading.battery<0.25)
-          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-        else
-          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-      });
-      
-    this.getService(Service.BatteryService)  
-      .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
-  }
+	//Items specific to Smoke Detectors:
+	if (this.device.last_reading.co_detected !== undefined) {
+		this.addService(Service.CarbonMonoxideSensor)
+			.getCharacteristic(Characteristic.CarbonMonoxideDetected)
+			.on('get', function (callback) {
+				if (that.device.last_reading.co_detected)
+					callback(null, Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL);
+				else
+					callback(null, Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL);
+			});
+		if (this.device.last_reading.battery !== undefined)
+			this.getService(Service.CarbonMonoxideSensor)
+				.getCharacteristic(Characteristic.StatusLowBattery)
+				.on('get', function (callback) {
+					if (that.device.last_reading.battery < 0.25)
+						callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+					else
+						callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+				});
+	}
+
+	if (this.device.last_reading.smoke_detected !== undefined) {
+		this.addService(Service.SmokeSensor)
+			.getCharacteristic(Characteristic.SmokeDetected)
+			.on('get', function (callback) {
+				if (that.device.last_reading.smoke_detected)
+					callback(null, Characteristic.SmokeDetected.SMOKE_DETECTED);
+				else
+					callback(null, Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
+			});
+		if (this.device.last_reading.battery !== undefined)
+			this.getService(Service.SmokeSensor)
+				.getCharacteristic(Characteristic.StatusLowBattery)
+				.on('get', function (callback) {
+					if (that.device.last_reading.battery < 0.25)
+						callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+					else
+						callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+				});
+	}
+
+	//Track the Battery Level
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.battery * 100));
+			});
+
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.battery < 0.25)
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
+
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
 //End Battery Level Tracking
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    if (this.device.last_reading.co_detected !== undefined) {
-        this.getService(Service.CarbonMonoxideSensor)
-            .getCharacteristic(Characteristic.CarbonMonoxideDetected)
-            .getValue();
+var loadData = function () {
+	if (this.device.last_reading.co_detected !== undefined) {
+		this.getService(Service.CarbonMonoxideSensor)
+			.getCharacteristic(Characteristic.CarbonMonoxideDetected)
+			.getValue();
 
-        if (this.device.last_reading.battery !== undefined) {
-            this.getService(Service.CarbonMonoxideSensor)
-                .getCharacteristic(Characteristic.StatusLowBattery)
-                .getValue();
-        }
-    }
+		if (this.device.last_reading.battery !== undefined) {
+			this.getService(Service.CarbonMonoxideSensor)
+				.getCharacteristic(Characteristic.StatusLowBattery)
+				.getValue();
+		}
+	}
 
-    if (this.device.last_reading.smoke_detected !== undefined) {
-        this.getService(Service.SmokeSensor)
-            .getCharacteristic(Characteristic.SmokeDetected)
-            .getValue();
+	if (this.device.last_reading.smoke_detected !== undefined) {
+		this.getService(Service.SmokeSensor)
+			.getCharacteristic(Characteristic.SmokeDetected)
+			.getValue();
 
-        if (this.device.last_reading.battery !== undefined) {
-            this.getService(Service.SmokeSensor)
-                .getCharacteristic(Characteristic.StatusLowBattery)
-                .getValue();
-        }
-    }
+		if (this.device.last_reading.battery !== undefined) {
+			this.getService(Service.SmokeSensor)
+				.getCharacteristic(Characteristic.StatusLowBattery)
+				.getValue();
+		}
+	}
 
-    if (this.device.last_reading.battery !== undefined) {
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .getValue();
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .getValue();
-    }
+	if (this.device.last_reading.battery !== undefined) {
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.getValue();
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.getValue();
+	}
 };

--- a/accessories/smoke_detectors.js
+++ b/accessories/smoke_detectors.js
@@ -1,4 +1,3 @@
-var wink = require('wink-js');
 var inherits = require('util').inherits;
 
 var WinkAccessory, Accessory, Service, Characteristic, uuid;

--- a/accessories/smoke_detectors.js
+++ b/accessories/smoke_detectors.js
@@ -1,0 +1,153 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Garage Door Accessory
+ */
+
+function WinkSmokeDetectorAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+  // Common Base Items
+  this.device = device;
+  this.name = device.name;
+  this.log = platform.log;
+  this.platform = platform;
+  this.deviceGroup='smoke_detectors';
+  this.deviceId=this.device.smoke_detector_id;
+
+ Service = oService;
+ Characteristic = oCharacteristic;
+ Accessory = oAccessory;
+ uuid = ouuid;
+
+  var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+  var id = uuid.generate(idKey);
+  Accessory.call(this, this.name, id);
+  this.uuid_base = id;
+
+  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+  //this.log(idKey+' '+ JSON.stringify(device));
+  var that = this;
+  // set some basic properties (these values are arbitrary and setting them is optional)
+  this
+      .getService(Service.AccessoryInformation)
+      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+      .setCharacteristic(Characteristic.Model, this.device.model_name)
+      .setCharacteristic(Characteristic.Name, this.device.name);
+      
+  //Items specific to Smoke Detectors:
+  if (this.device.last_reading.co_detected !== undefined) {
+    this.addService(Service.CarbonMonoxideSensor)  
+      .getCharacteristic(Characteristic.CarbonMonoxideDetected)
+      .on('get', function(callback) {
+        if (that.device.last_reading.co_detected)
+          callback(null, Characteristic.CarbonMonoxideDetected.CO_LEVELS_ABNORMAL);
+        else
+          callback(null, Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL);
+      });
+  if (this.device.last_reading.battery !== undefined)    
+    this.getService(Service.CarbonMonoxideSensor)  
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .on('get', function(callback) {
+        if (that.device.last_reading.battery<0.25)
+          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+        else
+          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+      });
+   }
+      
+  if (this.device.last_reading.smoke_detected !== undefined) {
+    this.addService(Service.SmokeSensor)  
+      .getCharacteristic(Characteristic.SmokeDetected)
+      .on('get', function(callback) {
+        if (that.device.last_reading.smoke_detected)
+          callback(null, Characteristic.SmokeDetected.SMOKE_DETECTED);
+        else
+          callback(null, Characteristic.SmokeDetected.SMOKE_NOT_DETECTED);
+      });
+  if (this.device.last_reading.battery !== undefined)    
+    this.getService(Service.SmokeSensor)  
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .on('get', function(callback) {
+        if (that.device.last_reading.battery<0.25)
+          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+        else
+          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+      });
+    }
+  
+  //Track the Battery Level
+  if (that.device.last_reading.battery !== undefined) {
+    this.addService(Service.BatteryService)  
+      .getCharacteristic(Characteristic.BatteryLevel)
+      .on('get', function(callback) {
+        callback(null, Math.floor(that.device.last_reading.battery*100));
+      });
+
+    this.getService(Service.BatteryService)  
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .on('get', function(callback) {
+        if (that.device.last_reading.battery<0.25)
+          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+        else
+          callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+      });
+      
+    this.getService(Service.BatteryService)  
+      .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+  }
+//End Battery Level Tracking     
+}
+
+WinkSmokeDetectorAccessory.prototype = {
+  loadData: function() {
+    
+  if (this.device.last_reading.co_detected !== undefined) {
+    this.getService(Service.CarbonMonoxideSensor)  
+      .getCharacteristic(Characteristic.CarbonMonoxideDetected)
+      .getValue();
+  if (this.device.last_reading.battery !== undefined)    
+    this.getService(Service.CarbonMonoxideSensor)  
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .getValue();
+   }
+      
+  if (this.device.last_reading.smoke_detected !== undefined) {
+    this.getService(Service.SmokeSensor)  
+      .getCharacteristic(Characteristic.SmokeDetected)
+      .getValue();
+  if (this.device.last_reading.battery !== undefined)    
+    this.getService(Service.SmokeSensor)  
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .getValue();
+    }
+  
+  
+  if (this.device.last_reading.battery !== undefined) {
+    this.getService(Service.BatteryService)  
+      .getCharacteristic(Characteristic.BatteryLevel)
+      .getValue();
+    this.getService(Service.BatteryService)  
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .getValue();
+    }
+  },
+  
+  getServices: function() {
+    return this.services;
+  },
+  
+  handleResponse: function(res) {
+    if (!res) {
+      return Error("No response from Wink");
+    } else if (res.errors && res.errors.length > 0) {
+      return res.errors[0];
+    } else if (res.data) {
+      this.device = res.data;
+      this.loadData();
+    }
+  }
+}
+module.exports = WinkSmokeDetectorAccessory;

--- a/accessories/thermostats.js
+++ b/accessories/thermostats.js
@@ -1,4 +1,3 @@
-var wink = require('wink-js');
 var inherits = require('util').inherits;
 
 var WinkAccessory, Accessory, Service, Characteristic, uuid;

--- a/accessories/thermostats.js
+++ b/accessories/thermostats.js
@@ -7,231 +7,230 @@ var WinkAccessory, Accessory, Service, Characteristic, uuid;
  *   Thermostat Accessory
  */
 
-module.exports = function(oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid)
-{
-    if (oWinkAccessory) {
-        WinkAccessory = oWinkAccessory;
-        Accessory = oAccessory;
-        Service = oService;
-        Characteristic = oCharacteristic;
-        uuid = ouuid;
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
 
-        inherits(WinkThermostatAccessory, WinkAccessory);
-        WinkThermostatAccessory.prototype.loadData = loadData;
-        WinkThermostatAccessory.prototype.deviceGroup = 'thermostats';
-    }
-    return WinkThermostatAccessory;
+		inherits(WinkThermostatAccessory, WinkAccessory);
+		WinkThermostatAccessory.prototype.loadData = loadData;
+		WinkThermostatAccessory.prototype.deviceGroup = 'thermostats';
+	}
+	return WinkThermostatAccessory;
 };
 module.exports.WinkThermostatAccessory = WinkThermostatAccessory;
 
 function WinkThermostatAccessory(platform, device) {
-    WinkAccessory.call(this, platform, device, device.thermostat_id);
+	WinkAccessory.call(this, platform, device, device.thermostat_id);
 
-    var that = this;
+	var that = this;
 
-    //Handle the Current State
-    this
-        .addService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-        .on('get', function(callback) {
-            if (that.device.last_reading.powered) { //I need to verify this changes when the thermostat clicks on.
-                switch (that.device.last_reading.mode) {
-                    case "cool_only":
-                        callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
-                        break;
-                    case "heat_only":
-                        callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
-                        break;
-                    case "auto": //HomeKit only accepts HEAT/COOL, so we have to determine if we are Heating or Cooling.
-                        if (that.device.last_reading.temperature < that.device.last_reading.min_set_point)
-                            callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
-                        else
-                            callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
-                        break;
-                    case "aux": //This assumes aux is always heat. Wink doesn't support aux with my thermostat even though I have aux mode, so I'm not 100%.
-                        callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
-                        break;
-                    default: //The above list should be inclusive, but we need to return something if they change stuff.
-                        callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
-                        break;
-                }
-            } else //For now, powered being false means it is off
-                callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
-        });
+	//Handle the Current State
+	this
+		.addService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+		.on('get', function (callback) {
+			if (that.device.last_reading.powered) { //I need to verify this changes when the thermostat clicks on.
+				switch (that.device.last_reading.mode) {
+					case "cool_only":
+						callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+						break;
+					case "heat_only":
+						callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
+						break;
+					case "auto": //HomeKit only accepts HEAT/COOL, so we have to determine if we are Heating or Cooling.
+						if (that.device.last_reading.temperature < that.device.last_reading.min_set_point)
+							callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
+						else
+							callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+						break;
+					case "aux": //This assumes aux is always heat. Wink doesn't support aux with my thermostat even though I have aux mode, so I'm not 100%.
+						callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
+						break;
+					default: //The above list should be inclusive, but we need to return something if they change stuff.
+						callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+						break;
+				}
+			} else //For now, powered being false means it is off
+				callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+		});
 
-    //Handle the Target State
-    //Handle the Current State
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-        .on('get', function(callback) {
-            if (that.device.desired_state.powered) { //I need to verify this changes when the thermostat clicks on.
-                switch (that.device.desired_state.mode) {
-                    case "cool_only":
-                        callback(null, Characteristic.TargetHeatingCoolingState.COOL);
-                        break;
-                    case "heat_only":
-                        callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
-                        break;
-                    case "auto":
-                        callback(null, Characteristic.TargetHeatingCoolingState.AUTO);
-                        break;
-                    case "aux": //This assumes aux is always heat. Wink doesn't support aux with my thermostat even though I have aux mode, so I'm not 100%.
-                        callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
-                        break;
-                    default: //The above list should be inclusive, but we need to return something if they change stuff.
-                        callback(null, Characteristic.TargetHeatingCoolingState.OFF);
-                        break;
-                }
-            } else //For now, powered being false means it is off
-                callback(null, Characteristic.TargetHeatingCoolingState.OFF);
-        })
-        .on('set', function(value, callback) {
-            switch (value) {
-                case Characteristic.TargetHeatingCoolingState.COOL:
-                    that.updatePropertyWithoutFeedback(callback, ["mode", "powered"], ["cool_only", true]);
-                    break;
-                case Characteristic.TargetHeatingCoolingState.HEAT:
-                    that.updatePropertyWithoutFeedback(callback, ["mode", "powered"], ["heat_only", true]);
-                    break;
-                case Characteristic.TargetHeatingCoolingState.AUTO:
-                    that.updatePropertyWithoutFeedback(callback, ["mode", "powered"], ["auto", true]);
-                    break;
-                case Characteristic.TargetHeatingCoolingState.OFF:
-                    that.updatePropertyWithoutFeedback(callback, "powered", false);
-                    break;
-            }
-        });
+	//Handle the Target State
+	//Handle the Current State
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+		.on('get', function (callback) {
+			if (that.device.desired_state.powered) { //I need to verify this changes when the thermostat clicks on.
+				switch (that.device.desired_state.mode) {
+					case "cool_only":
+						callback(null, Characteristic.TargetHeatingCoolingState.COOL);
+						break;
+					case "heat_only":
+						callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
+						break;
+					case "auto":
+						callback(null, Characteristic.TargetHeatingCoolingState.AUTO);
+						break;
+					case "aux": //This assumes aux is always heat. Wink doesn't support aux with my thermostat even though I have aux mode, so I'm not 100%.
+						callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
+						break;
+					default: //The above list should be inclusive, but we need to return something if they change stuff.
+						callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+						break;
+				}
+			} else //For now, powered being false means it is off
+				callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+		})
+		.on('set', function (value, callback) {
+			switch (value) {
+				case Characteristic.TargetHeatingCoolingState.COOL:
+					that.updatePropertyWithoutFeedback(callback, ["mode", "powered"], ["cool_only", true]);
+					break;
+				case Characteristic.TargetHeatingCoolingState.HEAT:
+					that.updatePropertyWithoutFeedback(callback, ["mode", "powered"], ["heat_only", true]);
+					break;
+				case Characteristic.TargetHeatingCoolingState.AUTO:
+					that.updatePropertyWithoutFeedback(callback, ["mode", "powered"], ["auto", true]);
+					break;
+				case Characteristic.TargetHeatingCoolingState.OFF:
+					that.updatePropertyWithoutFeedback(callback, "powered", false);
+					break;
+			}
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.temperature);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentTemperature)
+		.on('get', function (callback) {
+			callback(null, that.device.last_reading.temperature);
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.desired_state.min_set_point);
-        })
-        .on('set', function(value, callback) {
-            that.updatePropertyWithoutFeedback(callback, ["min_set_point", "max_set_point"], [value, value + 0.5555556]);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetTemperature)
+		.on('get', function (callback) {
+			callback(null, that.device.desired_state.min_set_point);
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, ["min_set_point", "max_set_point"], [value, value + 0.5555556]);
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-        .on('get', function(callback) {
-            if (platform.temperature_unit == "C")
-                callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
-            else
-                callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+		.on('get', function (callback) {
+			if (platform.temperature_unit == "C")
+				callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+			else
+				callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.HeatingThresholdTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.min_set_point);
-        })
-        .on('set', function(value, callback) {
-            that.updatePropertyWithoutFeedback(callback, "min_set_point", value);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.HeatingThresholdTemperature)
+		.on('get', function (callback) {
+			callback(null, that.device.last_reading.min_set_point);
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, "min_set_point", value);
+		});
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CoolingThresholdTemperature)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.max_set_point);
-        })
-        .on('set', function(value, callback) {
-            that.updatePropertyWithoutFeedback(callback, "max_set_point", value);
-        });
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CoolingThresholdTemperature)
+		.on('get', function (callback) {
+			callback(null, that.device.last_reading.max_set_point);
+		})
+		.on('set', function (value, callback) {
+			that.updatePropertyWithoutFeedback(callback, "max_set_point", value);
+		});
 
-    if (that.device.last_reading.humidity !== undefined)
-        this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .on('get', function(callback) {
-            callback(null, that.device.last_reading.humidity);
-        });
+	if (that.device.last_reading.humidity !== undefined)
+		this
+			.getService(Service.Thermostat)
+			.getCharacteristic(Characteristic.CurrentRelativeHumidity)
+			.on('get', function (callback) {
+				callback(null, that.device.last_reading.humidity);
+			});
 
-    //Track the Battery Level
-    if (that.device.last_reading.battery !== undefined) {
-        this.addService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .on('get', function(callback) {
-                callback(null, Math.floor(that.device.last_reading.battery * 100));
-            });
+	//Track the Battery Level
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.battery * 100));
+			});
 
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .on('get', function(callback) {
-                if (that.device.last_reading.battery < 0.25)
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
-                else
-                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
-            });
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.battery < 0.25)
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
 
-        this.getService(Service.BatteryService)
-            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
-    }
-    //End Battery Level Tracking
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
+	//End Battery Level Tracking
 
-    this.loadData();
+	this.loadData();
 }
 
-var loadData = function() {
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-        .getValue();
+var loadData = function () {
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetHeatingCoolingState)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentTemperature)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CurrentTemperature)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TargetTemperature)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TargetTemperature)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.TemperatureDisplayUnits)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.HeatingThresholdTemperature)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.HeatingThresholdTemperature)
+		.getValue();
 
-    this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CoolingThresholdTemperature)
-        .getValue();
+	this
+		.getService(Service.Thermostat)
+		.getCharacteristic(Characteristic.CoolingThresholdTemperature)
+		.getValue();
 
 
-    if (this.device.last_reading.humidity !== undefined)
-        this
-        .getService(Service.Thermostat)
-        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
-        .getValue();
+	if (this.device.last_reading.humidity !== undefined)
+		this
+			.getService(Service.Thermostat)
+			.getCharacteristic(Characteristic.CurrentRelativeHumidity)
+			.getValue();
 
-    if (this.device.last_reading.battery !== undefined) {
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.BatteryLevel)
-            .getValue();
-        this.getService(Service.BatteryService)
-            .getCharacteristic(Characteristic.StatusLowBattery)
-            .getValue();
-    }
+	if (this.device.last_reading.battery !== undefined) {
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.getValue();
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.getValue();
+	}
 };

--- a/accessories/thermostats.js
+++ b/accessories/thermostats.js
@@ -1,0 +1,262 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+
+var Service, Characteristic, Accessory, uuid;
+
+/*
+ *   Thermostat Accessory
+ */
+
+function WinkThermostatAccessory(platform, device, oService, oCharacteristic, oAccessory, ouuid) {
+    // Common Base Items
+    this.device = device;
+    this.name = device.name;
+    this.log = platform.log;
+    this.platform = platform;
+    this.deviceGroup = 'thermostats';
+    this.deviceId = this.device.thermostat_id;
+
+    Service = oService;
+    Characteristic = oCharacteristic;
+    Accessory = oAccessory;
+    uuid = ouuid;
+
+    var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+    var id = uuid.generate(idKey);
+    Accessory.call(this, this.name, id);
+    this.uuid_base = id;
+
+    this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+    //this.log(idKey+' '+ JSON.stringify(device));
+    var that = this;
+    // set some basic properties (these values are arbitrary and setting them is optional)
+    this
+        .getService(Service.AccessoryInformation)
+        .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+        .setCharacteristic(Characteristic.Model, this.device.model_name);
+
+    //Items specific to Thermostats:
+
+    //Handle the Current State
+    this
+        .addService(Service.Thermostat)
+        .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+        .on('get', function(callback) {
+            if (that.device.last_reading.powered) { //I need to verify this changes when the thermostat clicks on.
+                switch (that.device.last_reading.mode) {
+                    case "cool_only":
+                        callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+                        break;
+                    case "heat_only":
+                        callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
+                        break;
+                    case "auto": //HomeKit only accepts HEAT/COOL, so we have to determine if we are Heating or Cooling.
+                        if (that.device.last_reading.temperature < that.device.last_reading.min_set_point)
+                            callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
+                        else
+                            callback(null, Characteristic.CurrentHeatingCoolingState.COOL);
+                        break;
+                    case "aux": //This assumes aux is always heat. Wink doesn't support aux with my thermostat even though I have aux mode, so I'm not 100%.
+                        callback(null, Characteristic.CurrentHeatingCoolingState.HEAT);
+                        break;
+                    default: //The above list should be inclusive, but we need to return something if they change stuff.
+                        callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+                        break;
+                }
+            } else //For now, powered being false means it is off
+                callback(null, Characteristic.CurrentHeatingCoolingState.OFF);
+        });
+
+    //Handle the Target State
+    //Handle the Current State
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+        .on('get', function(callback) {
+            if (that.device.desired_state.powered) { //I need to verify this changes when the thermostat clicks on.
+                switch (that.device.desired_state.mode) {
+                    case "cool_only":
+                        callback(null, Characteristic.TargetHeatingCoolingState.COOL);
+                        break;
+                    case "heat_only":
+                        callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
+                        break;
+                    case "auto":
+                        callback(null, Characteristic.TargetHeatingCoolingState.AUTO);
+                        break;
+                    case "aux": //This assumes aux is always heat. Wink doesn't support aux with my thermostat even though I have aux mode, so I'm not 100%.
+                        callback(null, Characteristic.TargetHeatingCoolingState.HEAT);
+                        break;
+                    default: //The above list should be inclusive, but we need to return something if they change stuff.
+                        callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+                        break;
+                }
+            } else //For now, powered being false means it is off
+                callback(null, Characteristic.TargetHeatingCoolingState.OFF);
+        })
+        .on('set', function(value, callback) {
+            switch (value) {
+                case Characteristic.TargetHeatingCoolingState.COOL:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, ["mode", "powered"], ["cool_only", true]);
+                    break;
+                case Characteristic.TargetHeatingCoolingState.HEAT:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, ["mode", "powered"], ["heat_only", true]);
+                    break;
+                case Characteristic.TargetHeatingCoolingState.AUTO:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, ["mode", "powered"], ["auto", true]);
+                    break;
+                case Characteristic.TargetHeatingCoolingState.OFF:
+                    platform.UpdateWinkProperty_noFeedback(that, callback, "powered", false);
+                    break;
+            }
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.CurrentTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.temperature);
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.TargetTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.desired_state.min_set_point);
+        })
+        .on('set', function(value, callback) {
+            platform.UpdateWinkProperty_noFeedback(that, callback, ["min_set_point", "max_set_point"], [value, value + 0.5555556]);
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+        .on('get', function(callback) {
+            if (platform.temperature_unit == "C")
+                callback(null, Characteristic.TemperatureDisplayUnits.CELSIUS);
+            else
+                callback(null, Characteristic.TemperatureDisplayUnits.FAHRENHEIT);
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.HeatingThresholdTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.min_set_point);
+        })
+        .on('set', function(value, callback) {
+            platform.UpdateWinkProperty_noFeedback(that, callback, "min_set_point", value);
+        });
+
+    this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.CoolingThresholdTemperature)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.max_set_point);
+        })
+        .on('set', function(value, callback) {
+            platform.UpdateWinkProperty_noFeedback(that, callback, "max_set_point", value);
+        });
+
+    if (that.device.last_reading.humidity !== undefined)
+        this
+        .getService(Service.Thermostat)
+        .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+        .on('get', function(callback) {
+            callback(null, that.device.last_reading.humidity);
+        });
+
+    //Track the Battery Level
+    if (that.device.last_reading.battery !== undefined) {
+        this.addService(Service.BatteryService)
+            .getCharacteristic(Characteristic.BatteryLevel)
+            .on('get', function(callback) {
+                callback(null, Math.floor(that.device.last_reading.battery * 100));
+            });
+
+        this.getService(Service.BatteryService)
+            .getCharacteristic(Characteristic.StatusLowBattery)
+            .on('get', function(callback) {
+                if (that.device.last_reading.battery < 0.25)
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+                else
+                    callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+            });
+
+        this.getService(Service.BatteryService)
+            .setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+    }
+    //End Battery Level Tracking   
+}
+
+WinkThermostatAccessory.prototype = {
+    loadData: function() {
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.CurrentTemperature)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.TargetTemperature)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.HeatingThresholdTemperature)
+            .getValue();
+
+        this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.CoolingThresholdTemperature)
+            .getValue();
+
+
+        if (this.device.last_reading.humidity !== undefined)
+            this
+            .getService(Service.Thermostat)
+            .getCharacteristic(Characteristic.CurrentRelativeHumidity)
+            .getValue();
+
+        if (this.device.last_reading.battery !== undefined) {
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.BatteryLevel)
+                .getValue();
+            this.getService(Service.BatteryService)
+                .getCharacteristic(Characteristic.StatusLowBattery)
+                .getValue();
+        }
+    },
+
+    getServices: function() {
+        return this.services;
+    },
+
+    handleResponse: function(res) {
+        if (!res) {
+            return Error("No response from Wink");
+        } else if (res.errors && res.errors.length > 0) {
+            return res.errors[0];
+        } else if (res.data) {
+            this.device = res.data;
+            this.loadData();
+        }
+    }
+}
+module.exports = WinkThermostatAccessory;

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var WinkThermostatAccessory;
 var WinkAirConditionerAccessory;
 var WinkSensorAccessory;
 var WinkPropaneTankAccessory;
+var WinkSirenAccessory;
 
 module.exports = function (homebridge) {
 	Service = homebridge.hap.Service;
@@ -34,6 +35,7 @@ module.exports = function (homebridge) {
 	WinkAirConditionerAccessory = require('./accessories/air_conditioners')(WinkAccessory, Accessory, Service, Characteristic, uuid);
 	WinkSensorAccessory = require('./accessories/sensor_pods')(WinkAccessory, Accessory, Service, Characteristic, uuid);
 	WinkPropaneTankAccessory = require('./accessories/propane_tanks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkSirenAccessory = require('./accessories/sirens')(WinkAccessory, Accessory, Service, Characteristic, uuid);
 
 	homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
 };
@@ -74,7 +76,7 @@ WinkPlatform.prototype = {
 				for (var i = 0; i < devices.data.length; i++) {
 					var device = devices.data[i];
 					//NEWMODULE: Add the id here. I'm planning to redesign this section.
-					var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | device.propane_tank_id | ""];
+					var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | device.propane_tank_id | device.siren_id | ""];
 					if (accessory != undefined) {
 						accessory.device = device;
 						accessory.loadData();
@@ -147,6 +149,9 @@ WinkPlatform.prototype = {
 
 						else if (device.propane_tank_id !== undefined)
 							accessory = new WinkPropaneTankAccessory(that, device);
+
+						else if (device.siren_id !== undefined)
+							accessory = new WinkSirenAccessory(that, device);
 
 						//These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it
 						//with a HomeKit service yet.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 //
-
 var wink = require('wink-js');
 var inherits = require('util').inherits;
 
@@ -8,6 +7,12 @@ var WinkLockAccessory = require('./accessories/locks');
 var WinkLightAccessory = require('./accessories/light_bulbs');
 var WinkSwitchAccessory = require('./accessories/binary_switches');
 var WinkGarageDoorAccessory = require('./accessories/garage_doors');
+var WinkOutletAccessory = require('./accessories/outlets');
+var WinkSmokeDetectorAccessory = require('./accessories/smoke_detectors');
+var WinkThermostatAccessory = require('./accessories/thermostats');
+var WinkAirConditionerAccessory = require('./accessories/air_conditioners');
+var WinkSensorAccessory = require('./accessories/sensor_pods');
+
 process.env.WINK_NO_CACHE = true;
 
 var Service, Characteristic, Accessory, uuid;
@@ -19,190 +24,261 @@ module.exports = function(homebridge) {
     uuid = homebridge.hap.uuid;
     homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
 
-    var copyInherit = function(orig, base){
-      var acc = orig.prototype;
-      inherits(orig, base);
-      orig.prototype.parent = base.prototype;
-      for (var mn in acc) {
-          orig.prototype[mn] = acc[mn];
-      }
+    var copyInherit = function(orig, base) {
+        var acc = orig.prototype;
+        inherits(orig, base);
+        orig.prototype.parent = base.prototype;
+        for (var mn in acc) {
+            orig.prototype[mn] = acc[mn];
+        }
     }
-    
+
     //NEWMODULE: Add a line for inheriting the Accessory class
     copyInherit(WinkLockAccessory, Accessory);
     copyInherit(WinkLightAccessory, Accessory);
     copyInherit(WinkSwitchAccessory, Accessory);
     copyInherit(WinkGarageDoorAccessory, Accessory);
+    copyInherit(WinkOutletAccessory, Accessory);
+    copyInherit(WinkSmokeDetectorAccessory, Accessory);
+    copyInherit(WinkThermostatAccessory, Accessory);
+    copyInherit(WinkAirConditionerAccessory, Accessory);
+    copyInherit(WinkSensorAccessory, Accessory);
 };
-function WinkPlatform(log, config){
-  
 
-  
-  // auth info
-  this.client_id = config["client_id"];
-  this.client_secret = config["client_secret"];
+function WinkPlatform(log, config) {
+    // Load Wink Authentication From Config File
+    this.client_id = config["client_id"];
+    this.client_secret = config["client_secret"];
 
-  this.username = config["username"];
-  this.password = config["password"];
+    this.username = config["username"];
+    this.password = config["password"];
 
-  this.log = log;
-  this.deviceLookup = {};
+    // Load Groups or IDs that should be hidden from the Config File.
+    this.hidegroups = config["hide_groups"];
+    this.hideids = config["hide_ids"];
+    if (this.hidegroups == undefined) this.hidegroups = [];
+    if (this.hideids == undefined) this.hideids = [];
+
+    // If this is true then devices that the Wink hub cannot communicate with will not be registered.
+    // In addition, any devices that lose communication will be unregistered which will allow HomeKit to know the device is not accessible.
+    this.unregister_disconnected = config["unregister_disconnected"] | false;
+
+    //For Temperatures, what Display unit should we report (C or F)
+    this.temperature_unit = config["temperature_unit"];
+    if (this.temperature_unit === undefined) this.temperature_unit = "F";
+
+    this.log = log;
+    this.deviceLookup = {};
 }
 
 WinkPlatform.prototype = {
-  reloadData: function(callback) {
-    this.log("Refreshing Wink Data");
-    var that = this;
-    wink.user().devices(function(devices) {
-      if (devices && devices.data && devices.data instanceof Array) {
-        for (var i=0; i<devices.data.length; i++){
-          var device = devices.data[i];
-          //NEWMODULE: Add the id here. I'm planning to redesign this section.
-          var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | ""];
-          if (accessory != undefined) {
-            accessory.device = device;
-            accessory.loadData();
-          }
-        }
-      }
-      if (callback) callback();
-    });
-  },
-  accessories: function(callback) {
-    this.log("Fetching Wink devices.");
-
-    var that = this;
-    var foundAccessories = [];
-    this.deviceLookup = {};
-
-    var refreshLoop = function(){
-      setInterval(that.reloadData.bind(that), 30000);
-    };
-
-    wink.init({
-        "client_id": this.client_id,
-        "client_secret": this.client_secret,
-        "username": this.username,
-        "password": this.password
-    }, function(auth_return) {
-      if ( auth_return === undefined ) {
-        that.log("There was a problem authenticating with Wink.");
-      } else {
-        // success
-        wink.user().devices(function(devices) {
-          for (var i=0; i<devices.data.length; i++){
-            var device = devices.data[i];
-            var accessory = null;
-            
-              //Get Device Type
-//NEWMODULE: Uncomment and complete the appropriate lines here.
-  if (device.light_bulb_id !== undefined)
-    accessory = new WinkLightAccessory(that, device, Service, Characteristic, Accessory, uuid);
-  else if (device.garage_door_id !== undefined) 
-    accessory = new WinkGarageDoorAccessory(that, device, Service, Characteristic, Accessory, uuid);
-  else if (device.lock_id !== undefined) 
-    accessory = new WinkLockAccessory(that, device, Service, Characteristic, Accessory, uuid);
-  else if (device.binary_switch_id !== undefined) 
-    accessory = new WinkSwitchAccessory(that, device, Service, Characteristic, Accessory, uuid);
-  //else i (device.sensor_id !== undefined) { this.device_group='sensor'; this.device_id=this.device.sensor_id; }
-  //else i (device.smoke_detector_id !== undefined) { this.device_group='smoke_detector'; this.device_id=this.device.smoke_detector_id; }
-  //else i (device.thermostat_id !== undefined) { this.device_group='thermostat'; this.device_id=this.device.thermostat_id; }
-  
-  
-  //else i (device.power_strip_id !== undefined) { this.device_group='power_strip'; this.device_id=this.device.power_strip_id; }
-  //else i (device.outlet_id !== undefined) { this.device_group='outlet'; this.device_id=this.device.outlet_id; }
-  //else i (device.air_conditioner_id !== undefined) { this.device_group='air_conditioner'; this.device_id=this.device.air_conditioner_id; }
-  //else i (device.shade_id !== undefined) { this.device_group='shade'; this.device_id=this.device.shade_id; }
-  //else i (device.camera_id !== undefined) { this.device_group='camera'; this.device_id=this.device.camera_id; }
-  //else i (device.doorbell_id !== undefined) { this.device_group='doorbell'; this.device_id=this.device.doorbell_id; }
-  //else i (device.cloud_clock_id !== undefined) { this.device_group='cloud_clock'; this.device_id=this.device.cloud_clock_id; }
-  //else i (device.alarm_id !== undefined) { this.device_group='alarm'; this.device_id=this.device.alarm_id; }
-  //else i (device.piggy_bank_id !== undefined) { this.device_group='piggy_bank'; this.device_id=this.device.piggy_bank_id; }
-  //else i (device.deposit_id !== undefined) { this.device_group='deposit'; this.device_id=this.device.deposit_id; }
-  //else i (device.refrigerator_id !== undefined) { this.device_group='refrigerator'; this.device_id=this.device.refrigerator_id; }
-  //else i (device.propane_tank_id !== undefined) { this.device_group='propane_tank'; this.device_id=this.device.propane_tank_id; }
-  //else i (device.remote_id !== undefined) { this.device_group='remote'; this.device_id=this.device.remote_id; }
-  //else i (device.siren_id !== undefined) { this.device_group='siren'; this.device_id=this.device.siren_id; }
-  //else i (device.sprinkler_id !== undefined) { this.device_group='sprinkler'; this.device_id=this.device.sprinkler_id; }
-  //else i (device.water_heater_id !== undefined) { this.device_group='water_heater'; this.device_id=this.device.water_heater_id; }
-  //else i (device.unknown_device_id !== undefined) { this.device_group='unknown_device'; this.device_id=this.device.unknown_device_id; }
-  //else i (device.hub_id !== undefined) { this.device_group='hub'; this.device_id=this.device.hub_id; }
-  
-            
-            if (accessory != undefined) {
-              that.deviceLookup[accessory.deviceId] = accessory;
-              foundAccessories.push(accessory);
-            }
-          }
-          refreshLoop();
-          callback(foundAccessories);
-        });
-      }
-    });
-  },
-  UpdateWinkProperty_noFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
-    this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
-    if (WinkAccessory.device.desired_state == undefined) { callback(Error("Unsupported")); return; };
-    if (WinkAccessory.device.desired_state[sProperty] == undefined) { callback(Error("Unsupported")); return; };
-
-    var myvariable = { "desired_state": {  } };
-    myvariable.desired_state[sProperty]=sTarget;
-    WinkAccessory.control.update(myvariable, callback);
-  },
-  refreshUntil: function(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty) {
-    if (!interval) {
-      interval = 500;
-    }
-    if (!incrementInterval) {
-      incrementInterval = 500;
-    }
-    setTimeout(function() {
-      that.reloadData(function() {
-        if (predicate == undefined || predicate(that.device, sProperty) == true) {
-          if (callback) callback(true, that.device, sProperty);
-        } else if (maxTimes > 0) {
-          maxTimes = maxTimes - 1;
-          interval += incrementInterval;
-          this.refreshUntil(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty);
-        } else {
-          if (callback) callback(false, that.device, sProperty);
-        }
-      });
-    }, interval);
-  },
-  UpdateWinkProperty_withFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
-    this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
-    if (WinkAccessory.device.desired_state == undefined) { callback(Error("Unsupported")); return; };
-    if (WinkAccessory.device.desired_state[sProperty] == undefined) { callback(Error("Unsupported")); return; };
-
-    var myvariable = { "desired_state": {  } };
-    myvariable.desired_state[sProperty]=sTarget;
-    
-    var update = function(retry) {
-          WinkAccessory.control.update(myvariable, 
-            function(res) {
-              var err = WinkAccessory.handleResponse(res);
-              if (!err) {
-                this.refreshUntil(WinkAccessory.device, 5,
-                  function(sProperty) { return WinkAccessory.device.last_reading[sProperty] == WinkAccessory.device.desired_state[sProperty]; },
-                  function(completed, device, sProperty) {
-                    if (completed) {
-                      this.log("Successfully changed target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
-                    } else if (retry) {
-                      this.log("Unable to determine if update was successful. Retrying update.");
-                      retry();
-                    } else {
-                      this.log("Unable to determine if update was successful.");
+    reloadData: function(callback) {
+        //This is called when we need to refresh all Wink device information.
+        this.log("Refreshing Wink Data");
+        var that = this;
+        wink.user().devices(function(devices) { //TODO: Add the ability to detect new devices and unregister newly disconnected devices.
+            if (devices && devices.data && devices.data instanceof Array) {
+                for (var i = 0; i < devices.data.length; i++) {
+                    var device = devices.data[i];
+                    //NEWMODULE: Add the id here. I'm planning to redesign this section.
+                    var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | ""];
+                    if (accessory != undefined) {
+                        accessory.device = device;
+                        accessory.loadData();
                     }
-                  });
+                }
             }
-            if (callback)
-            {
-              callback(err);
-              callback = null;
+            if (callback) callback();
+        });
+    },
+    accessories: function(callback) {
+        this.log("Fetching Wink devices.");
+
+        var that = this;
+        var foundAccessories = [];
+        this.deviceLookup = {};
+
+        var refreshLoop = function() {
+            setInterval(that.reloadData.bind(that), 30000);
+        };
+
+        wink.init({
+            "client_id": this.client_id,
+            "client_secret": this.client_secret,
+            "username": this.username,
+            "password": this.password
+        }, function(auth_return) {
+            if (auth_return === undefined) {
+                that.log("There was a problem authenticating with Wink.");
+            } else {
+                // success
+                wink.user().devices(function(devices) {
+                    for (var i = 0; i < devices.data.length; i++) {
+                        var device = devices.data[i];
+                        var accessory = null;
+                        //Get Device Type
+                        //NEWMODULE: Add Appropriate Lines Here
+                        if (device.light_bulb_id !== undefined)
+                            accessory = new WinkLightAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.garage_door_id !== undefined)
+                            accessory = new WinkGarageDoorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.lock_id !== undefined)
+                            accessory = new WinkLockAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.binary_switch_id !== undefined)
+                            accessory = new WinkSwitchAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.powerstrip_id !== undefined) {
+                            for (var j = 0; j < device.outlets.length; j++) {
+                                accessory = new WinkOutletAccessory(that, device.outlets[j], Service, Characteristic, Accessory, uuid);
+                                if (accessory != undefined) {
+                                    that.deviceLookup[accessory.deviceId] = accessory;
+                                    foundAccessories.push(accessory);
+                                }
+                                accessory = undefined;
+                            }
+
+                        } else if (device.smoke_detector_id !== undefined)
+                            accessory = new WinkSmokeDetectorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.thermostat_id !== undefined)
+                            accessory = new WinkThermostatAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.air_conditioner_id !== undefined)
+                            accessory = new WinkAirConditionerAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        else if (device.sensor_pod_id !== undefined)
+                            accessory = new WinkSensorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+                        //These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it 
+                        //with a HomeKit service yet.
+                        else if (device.manufacturer_device_model = "wink_hub")
+                            that.log("Device Ignored Not In HomeKit - Group hubs, ID " + device.hub_id + ", Name " + device.name);
+                        else if (device.remote_id !== undefined)
+                            that.log("Device Ignored Not In HomeKit - Group remotes, ID " + device.remote_id + ", Name " + device.name);
+                        else if (device.unknown_device_id !== undefined)
+                            that.log("Device Ignored Not In HomeKit - Group unknown_devices, ID " + device.unknown_device_id + ", Name " + device.name);
+                        else if (device.eggtray_id !== undefined)
+                            that.log("Device Ignored Not In HomeKit - Group eggtrays, ID " + device.eggtray_id + ", Name " + device.name);
+                        else if (device.piggy_bank_id !== undefined)
+                            that.log("Device Ignored Not In HomeKit - Group piggy_banks, ID " + device.piggy_bank_id + ", Name " + device.name);
+
+                        else that.log("Unknown Device Group: " + JSON.stringify(device));
+
+                        if (accessory != undefined) {
+                            if (that.hidegroups.indexOf(accessory.deviceGroup) >= 0) { //Make sure the group isn't supposed to be hidden
+                                that.log("Device Ignored By Group - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+                            } else if (that.hideids.indexOf(accessory.deviceId) >= 0) { //Make sure the ID isn't supposed to be hidden
+                                that.log("Device Ignored By ID - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+                            } else if (that.unregister_disconnected && !accessory.device.last_reading.connection) {
+                                that.log("Device Ignored By Disconnection - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+                            } else {
+                                that.log("Device Added - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+                                that.deviceLookup[accessory.deviceId] = accessory;
+                                foundAccessories.push(accessory);
+                            }
+                        }
+                    }
+                    refreshLoop();
+                    callback(foundAccessories);
+                });
             }
-          });
+        });
+    },
+    UpdateWinkProperty_noFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
+        this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
+        if (WinkAccessory.device.desired_state == undefined) {
+            callback(Error("Unsupported"));
+            return;
+        };
+
+
+        var myvariable = {
+            "desired_state": {}
+        };
+
+        if (sProperty instanceof Array) {
+            for (var i = 0; i < sProperty.length; i++) {
+                myvariable.desired_state[sProperty[i]] = sTarget[i];
+            }
+        } else {
+            if (WinkAccessory.device.desired_state[sProperty] == undefined) {
+                callback(Error("Unsupported"));
+                return;
+            };
+            myvariable.desired_state[sProperty] = sTarget;
+        }
+
+
+        WinkAccessory.control.update(myvariable, callback);
+
+    },
+    UpdateWinkProperty_withFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
+        this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
+        if (WinkAccessory.device.desired_state == undefined) {
+            callback(Error("Unsupported"));
+            return;
+        };
+        if (WinkAccessory.device.desired_state[sProperty] == undefined) {
+            callback(Error("Unsupported"));
+            return;
+        };
+
+        var myvariable = {
+            "desired_state": {}
+        };
+        myvariable.desired_state[sProperty] = sTarget;
+        var that = this;
+        var update = function(retry) {
+            WinkAccessory.control.update(myvariable,
+                function(res) {
+                    var err = WinkAccessory.handleResponse(res);
+                    if (!err) {
+                        that.refreshUntil(WinkAccessory, 5,
+                            function(sProperty) {
+                                return WinkAccessory.device.last_reading[sProperty] == WinkAccessory.device.desired_state[sProperty];
+                            },
+                            function(completed, device, sProperty) {
+                                if (completed) {
+                                    that.log("Successfully changed target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
+                                } else if (retry) {
+                                    that.log("Unable to determine if update was successful. Retrying update.");
+                                    retry();
+                                } else {
+                                    that.log("Unable to determine if update was successful.");
+                                }
+                            }, 1000, 500, sProperty);
+                    }
+                    if (callback) {
+                        callback(err);
+                        callback = null;
+                    }
+                });
         };
         update(update);
-  }
+    },
+    refreshUntil: function(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty) {
+        if (!interval) {
+            interval = 500;
+        }
+        if (!incrementInterval) {
+            incrementInterval = 500;
+        }
+        setTimeout(function() {
+            that.control.refresh(function() {
+                if (predicate == undefined || predicate(sProperty) == true) {
+                    if (callback) callback(true, that.device, sProperty);
+                } else if (maxTimes > 0) {
+                    maxTimes = maxTimes - 1;
+                    interval += incrementInterval;
+                    that.platform.refreshUntil(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty);
+                } else {
+                    if (callback) callback(false, that.device, sProperty);
+                }
+            });
+        }, interval);
+    }
+
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
+//
+
 var wink = require('wink-js');
 var inherits = require('util').inherits;
 
+//NEWMODULE: Add the object reference here
+var WinkLockAccessory = require('./accessories/locks');
+var WinkLightAccessory = require('./accessories/light_bulbs');
+var WinkSwitchAccessory = require('./accessories/binary_switches');
+var WinkGarageDoorAccessory = require('./accessories/garage_doors');
 process.env.WINK_NO_CACHE = true;
 
 var Service, Characteristic, Accessory, uuid;
@@ -10,6 +17,7 @@ module.exports = function(homebridge) {
     Characteristic = homebridge.hap.Characteristic;
     Accessory = homebridge.hap.Accessory;
     uuid = homebridge.hap.uuid;
+    homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
 
     var copyInherit = function(orig, base){
       var acc = orig.prototype;
@@ -18,19 +26,18 @@ module.exports = function(homebridge) {
       for (var mn in acc) {
           orig.prototype[mn] = acc[mn];
       }
-    };
-
-    copyInherit(WinkAccessory, Accessory);
-    copyInherit(WinkLightAccessory, WinkAccessory);
-    copyInherit(WinkLockAccessory, WinkAccessory);
-
-    homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
+    }
+    
+    //NEWMODULE: Add a line for inheriting the Accessory class
+    copyInherit(WinkLockAccessory, Accessory);
+    copyInherit(WinkLightAccessory, Accessory);
+    copyInherit(WinkSwitchAccessory, Accessory);
+    copyInherit(WinkGarageDoorAccessory, Accessory);
 };
-var model = wink.model;
-
-
 function WinkPlatform(log, config){
+  
 
+  
   // auth info
   this.client_id = config["client_id"];
   this.client_secret = config["client_secret"];
@@ -47,12 +54,15 @@ WinkPlatform.prototype = {
     this.log("Refreshing Wink Data");
     var that = this;
     wink.user().devices(function(devices) {
-      for (var i=0; i<devices.data.length; i++){
-        var device = devices.data[i];
-        var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | ""];
-        if (accessory != undefined) {
-          accessory.device = device;
-          accessory.loadData();
+      if (devices && devices.data && devices.data instanceof Array) {
+        for (var i=0; i<devices.data.length; i++){
+          var device = devices.data[i];
+          //NEWMODULE: Add the id here. I'm planning to redesign this section.
+          var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | ""];
+          if (accessory != undefined) {
+            accessory.device = device;
+            accessory.loadData();
+          }
         }
       }
       if (callback) callback();
@@ -84,11 +94,41 @@ WinkPlatform.prototype = {
             var device = devices.data[i];
             var accessory = null;
             
-            if (device.light_bulb_id !== undefined) {
-              accessory = new WinkLightAccessory(that.log, device);
-            } else if (device.lock_id !== undefined) {
-              accessory = new WinkLockAccessory(that.log, device);
-            }
+              //Get Device Type
+//NEWMODULE: Uncomment and complete the appropriate lines here.
+  if (device.light_bulb_id !== undefined)
+    accessory = new WinkLightAccessory(that, device, Service, Characteristic, Accessory, uuid);
+  else if (device.garage_door_id !== undefined) 
+    accessory = new WinkGarageDoorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+  else if (device.lock_id !== undefined) 
+    accessory = new WinkLockAccessory(that, device, Service, Characteristic, Accessory, uuid);
+  else if (device.binary_switch_id !== undefined) 
+    accessory = new WinkSwitchAccessory(that, device, Service, Characteristic, Accessory, uuid);
+  //else i (device.sensor_id !== undefined) { this.device_group='sensor'; this.device_id=this.device.sensor_id; }
+  //else i (device.smoke_detector_id !== undefined) { this.device_group='smoke_detector'; this.device_id=this.device.smoke_detector_id; }
+  //else i (device.thermostat_id !== undefined) { this.device_group='thermostat'; this.device_id=this.device.thermostat_id; }
+  
+  
+  //else i (device.power_strip_id !== undefined) { this.device_group='power_strip'; this.device_id=this.device.power_strip_id; }
+  //else i (device.outlet_id !== undefined) { this.device_group='outlet'; this.device_id=this.device.outlet_id; }
+  //else i (device.air_conditioner_id !== undefined) { this.device_group='air_conditioner'; this.device_id=this.device.air_conditioner_id; }
+  //else i (device.shade_id !== undefined) { this.device_group='shade'; this.device_id=this.device.shade_id; }
+  //else i (device.camera_id !== undefined) { this.device_group='camera'; this.device_id=this.device.camera_id; }
+  //else i (device.doorbell_id !== undefined) { this.device_group='doorbell'; this.device_id=this.device.doorbell_id; }
+  //else i (device.cloud_clock_id !== undefined) { this.device_group='cloud_clock'; this.device_id=this.device.cloud_clock_id; }
+  //else i (device.alarm_id !== undefined) { this.device_group='alarm'; this.device_id=this.device.alarm_id; }
+  //else i (device.piggy_bank_id !== undefined) { this.device_group='piggy_bank'; this.device_id=this.device.piggy_bank_id; }
+  //else i (device.deposit_id !== undefined) { this.device_group='deposit'; this.device_id=this.device.deposit_id; }
+  //else i (device.refrigerator_id !== undefined) { this.device_group='refrigerator'; this.device_id=this.device.refrigerator_id; }
+  //else i (device.propane_tank_id !== undefined) { this.device_group='propane_tank'; this.device_id=this.device.propane_tank_id; }
+  //else i (device.remote_id !== undefined) { this.device_group='remote'; this.device_id=this.device.remote_id; }
+  //else i (device.siren_id !== undefined) { this.device_group='siren'; this.device_id=this.device.siren_id; }
+  //else i (device.sprinkler_id !== undefined) { this.device_group='sprinkler'; this.device_id=this.device.sprinkler_id; }
+  //else i (device.water_heater_id !== undefined) { this.device_group='water_heater'; this.device_id=this.device.water_heater_id; }
+  //else i (device.unknown_device_id !== undefined) { this.device_group='unknown_device'; this.device_id=this.device.unknown_device_id; }
+  //else i (device.hub_id !== undefined) { this.device_group='hub'; this.device_id=this.device.hub_id; }
+  
+            
             if (accessory != undefined) {
               that.deviceLookup[accessory.deviceId] = accessory;
               foundAccessories.push(accessory);
@@ -99,233 +139,60 @@ WinkPlatform.prototype = {
         });
       }
     });
-  }
-};
+  },
+  UpdateWinkProperty_noFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
+    this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
+    if (WinkAccessory.device.desired_state == undefined) { callback(Error("Unsupported")); return; };
+    if (WinkAccessory.device.desired_state[sProperty] == undefined) { callback(Error("Unsupported")); return; };
 
-
-/*
- *   Base Accessory
- */
-
-function WinkAccessory(log, device, type, typeId) {
-  // construct base
-  this.device = device;
-  this.name = device.name;
-  
-  this.log = log;
-  if (typeId == undefined) {
-    typeId = this.name;
-    log("WARN: Unable to find id of " + this.name + " so using name instead");
-  }
-  this.deviceGroup = type + 's';
-  this.deviceId = typeId;
-  var idKey = 'hbdev:wink:' + type + ':' + typeId;
-  var id = uuid.generate(idKey);
-  Accessory.call(this, this.name, id);
-  this.uuid_base = id;
-
-  this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
-
-  // set some basic properties (these values are arbitrary and setting them is optional)
-  this
-      .getService(Service.AccessoryInformation)
-      .setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
-      .setCharacteristic(Characteristic.Model, this.device.model_name)
-      .setCharacteristic(Characteristic.Name, this.device.name);
-
-  WinkAccessory.prototype.loadData.call(this);
-}
-
-WinkAccessory.prototype.getServices = function() {
-  return this.services;
-};
-
-WinkAccessory.prototype.loadData = function() {
-};
-
-WinkAccessory.prototype.handleResponse = function(res) {
-  if (!res) {
-    return Error("No response from Wink");
-  } else if (res.errors && res.errors.length > 0) {
-    return res.errors[0];
-  } else if (res.data) {
-    this.device = res.data;
-    this.loadData();
-  }
-};
-
-WinkAccessory.prototype.reloadData = function(callback){
-  var that = this;
-  this.control.get(function(res) {
-    callback(that.handleResponse(res));
-  });
-};
-
-
-/*
- *   Light Accessory
- */
-
-function WinkLightAccessory(log, device) {
-  // construct base
-  WinkAccessory.call(this, log, device, 'light_bulb', device.light_bulb_id);
-
-  // accessor
-  var that = this;
-
-  that.device = device;
-  that.deviceControl = model.light_bulbs(device, wink);
- 
-  this
-      .addService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .on('get', function(callback) {
-        var powerState = that.device.last_reading.powered;
-        callback(null, powerState != undefined ? powerState : false);
-      })
-      .on('set', function(powerOn, callback) {
-        if (powerOn) {
-          that.deviceControl.power.on(function(response) {
-            if (response === undefined) {
-              callback(Error("Error setting power state on the '"+that.name+"'"));
-            } else {
-              callback(null, powerOn);
-            }
-          });
-        }else{
-          that.deviceControl.power.off(function(response) {
-            if (response === undefined) {
-              callback(Error("Error setting power state on the '"+that.name+"'"));
-            } else {
-              callback(null, powerOn);
-            }
-          });
+    var myvariable = { "desired_state": {  } };
+    myvariable.desired_state[sProperty]=sTarget;
+    WinkAccessory.control.update(myvariable, callback);
+  },
+  refreshUntil: function(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty) {
+    if (!interval) {
+      interval = 500;
+    }
+    if (!incrementInterval) {
+      incrementInterval = 500;
+    }
+    setTimeout(function() {
+      that.reloadData(function() {
+        if (predicate == undefined || predicate(that.device, sProperty) == true) {
+          if (callback) callback(true, that.device, sProperty);
+        } else if (maxTimes > 0) {
+          maxTimes = maxTimes - 1;
+          interval += incrementInterval;
+          this.refreshUntil(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty);
+        } else {
+          if (callback) callback(false, that.device, sProperty);
         }
       });
+    }, interval);
+  },
+  UpdateWinkProperty_withFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
+    this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
+    if (WinkAccessory.device.desired_state == undefined) { callback(Error("Unsupported")); return; };
+    if (WinkAccessory.device.desired_state[sProperty] == undefined) { callback(Error("Unsupported")); return; };
 
-  this
-      .getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Brightness)
-      .on('get', function(callback) {
-        var level = that.device.last_reading.brightness * 100;
-        callback(null, level);
-      })
-      .on('set', function(level, callback) {
-        that.deviceControl.brightness(level, function(response) {
-          if (response === undefined) {
-            callback(Error("Error setting brightness on the '"+that.name+"'"));
-          } else {
-            callback(null, level);
-          }
-        });
-      });
-
-  WinkLightAccessory.prototype.loadData.call(this);
-}
-
-WinkLightAccessory.prototype.loadData = function() {
-  this.parent.loadData.call(this);
-  this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .getValue();
-  this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.Brightness)
-      .getValue();
-};
-
-/*
- *   Switch Accessory
- */
-
-function WinkSwitchAccessory(log, device) {
-  // construct base
-  WinkAccessory.call(this, log, device, 'binary_switches', device.binary_switch_id);
-
-  // accessor
-  var that = this;
-
-  that.device = device;
-  that.deviceControl = model.binary_switches(device, wink);
- 
-  this
-      .addService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .on('get', function(callback) {
-        var powerState = that.device.last_reading.powered;
-        callback(null, powerState != undefined ? powerState : false);
-      })
-      .on('set', function(powerOn, callback) {
-        if (powerOn) {
-          that.deviceControl.power.on(function(response) {
-            if (response === undefined) {
-              callback(Error("Error setting power state on the '"+that.name+"'"));
-            } else {
-              callback(null, powerOn);
-            }
-          });
-        }else{
-          that.deviceControl.power.off(function(response) {
-            if (response === undefined) {
-              callback(Error("Error setting power state on the '"+that.name+"'"));
-            } else {
-              callback(null, powerOn);
-            }
-          });
-        }
-      });
-
-  WinkSwitchAccessory.prototype.loadData.call(this);
-}
-
-WinkSwitchAccessory.prototype.loadData = function() {
-  this.parent.loadData.call(this);
-  this.getService(Service.Lightbulb)
-      .getCharacteristic(Characteristic.On)
-      .getValue();
-};
-
-
-/*
- *   Lock Accessory
- */
-
-function WinkLockAccessory(log, device) {
-  // construct base
-  WinkAccessory.call(this, log, device, 'lock', device.lock_id);
-
-  // accessor
-  var that = this;
-
-  this
-      .addService(Service.LockMechanism)
-      .getCharacteristic(Characteristic.LockTargetState)
-      .on('get', function(callback) {
-        callback(null, that.isLockTarget());
-      })
-      .on('set', function(value, callback) {
-        var locked = that.fromLockState(value);
-
-        if (locked == undefined) {
-          callback(Error("Unsupported"));
-          return;
-        }
-
-        that.log("Changing target lock state of " + that.name + " to " + (locked ? "locked" : "unlocked"));
-
-        var update = function(retry) {
-          that.control.update({ "desired_state": { "locked": locked } }, function(res) {
-            var err = that.handleResponse(res);
-            if (!err) {
-              model.refreshUntil(that, 5,
-                  function() { return that.isLocked() == that.isLockTarget(); },
-                  function(completed) {
+    var myvariable = { "desired_state": {  } };
+    myvariable.desired_state[sProperty]=sTarget;
+    
+    var update = function(retry) {
+          WinkAccessory.control.update(myvariable, 
+            function(res) {
+              var err = WinkAccessory.handleResponse(res);
+              if (!err) {
+                this.refreshUntil(WinkAccessory.device, 5,
+                  function(sProperty) { return WinkAccessory.device.last_reading[sProperty] == WinkAccessory.device.desired_state[sProperty]; },
+                  function(completed, device, sProperty) {
                     if (completed) {
-                      that.log("Successfully changed lock status to " + (that.isLocked() ? "locked" : "unlocked"));
+                      this.log("Successfully changed target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
                     } else if (retry) {
-                      that.log("Unable to determine if update was successful. Retrying update.");
+                      this.log("Unable to determine if update was successful. Retrying update.");
                       retry();
                     } else {
-                      that.log("Unable to determine if update was successful.");
+                      this.log("Unable to determine if update was successful.");
                     }
                   });
             }
@@ -337,39 +204,5 @@ function WinkLockAccessory(log, device) {
           });
         };
         update(update);
-      });
-
-  WinkLockAccessory.prototype.loadData.call(this);
-}
-
-WinkLockAccessory.prototype.loadData = function() {
-  this.parent.loadData.call(this);
-  this.getService(Service.LockMechanism)
-      .setCharacteristic(Characteristic.LockCurrentState, this.isLocked());
-  this.getService(Service.LockMechanism)
-      .getCharacteristic(Characteristic.LockTargetState)
-      .getValue();
-};
-
-WinkLockAccessory.prototype.toLockState= function(isLocked) {
-  return isLocked  ? Characteristic.LockCurrentState.SECURED : Characteristic.LockCurrentState.UNSECURED;
-};
-
-WinkLockAccessory.prototype.fromLockState= function(lockState) {
-  switch (lockState) {
-    case Characteristic.LockCurrentState.SECURED:
-      return true;
-    case Characteristic.LockCurrentState.UNSECURED:
-      return false;
-    default:
-      return undefined;
   }
-};
-
-WinkLockAccessory.prototype.isLockTarget= function() {
-  return this.toLockState(this.device.desired_state.locked);
-};
-
-WinkLockAccessory.prototype.isLocked= function() {
-  return this.toLockState(this.device.last_reading.locked);
 };

--- a/index.js
+++ b/index.js
@@ -1,50 +1,41 @@
 //
 var wink = require('wink-js');
-var inherits = require('util').inherits;
-
-//NEWMODULE: Add the object reference here
-var WinkLockAccessory = require('./accessories/locks');
-var WinkLightAccessory = require('./accessories/light_bulbs');
-var WinkSwitchAccessory = require('./accessories/binary_switches');
-var WinkGarageDoorAccessory = require('./accessories/garage_doors');
-var WinkOutletAccessory = require('./accessories/outlets');
-var WinkSmokeDetectorAccessory = require('./accessories/smoke_detectors');
-var WinkThermostatAccessory = require('./accessories/thermostats');
-var WinkAirConditionerAccessory = require('./accessories/air_conditioners');
-var WinkSensorAccessory = require('./accessories/sensor_pods');
-var WinkPropaneTankAccessory = require('./accessories/propane_tanks');
 
 process.env.WINK_NO_CACHE = true;
 
 var Service, Characteristic, Accessory, uuid;
+
+var WinkAccessory;
+var WinkLockAccessory;
+var WinkLightAccessory;
+var WinkSwitchAccessory;
+var WinkGarageDoorAccessory;
+var WinkOutletAccessory;
+var WinkSmokeDetectorAccessory;
+var WinkThermostatAccessory;
+var WinkAirConditionerAccessory;
+var WinkSensorAccessory;
+var WinkPropaneTankAccessory;
 
 module.exports = function(homebridge) {
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
     Accessory = homebridge.hap.Accessory;
     uuid = homebridge.hap.uuid;
+
+    WinkAccessory = require('./lib/wink-accessory')(Accessory, Service, Characteristic, uuid);
+    WinkLockAccessory = require('./accessories/locks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkLightAccessory = require('./accessories/light_bulbs')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkSwitchAccessory = require('./accessories/binary_switches')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkGarageDoorAccessory = require('./accessories/garage_doors')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkOutletAccessory = require('./accessories/outlets')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkSmokeDetectorAccessory = require('./accessories/smoke_detectors')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkThermostatAccessory = require('./accessories/thermostats')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkAirConditionerAccessory = require('./accessories/air_conditioners')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkSensorAccessory = require('./accessories/sensor_pods')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+    WinkPropaneTankAccessory = require('./accessories/propane_tanks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+
     homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
-
-    var copyInherit = function(orig, base) {
-        var acc = orig.prototype;
-        inherits(orig, base);
-        orig.prototype.parent = base.prototype;
-        for (var mn in acc) {
-            orig.prototype[mn] = acc[mn];
-        }
-    }
-
-    //NEWMODULE: Add a line for inheriting the Accessory class
-    copyInherit(WinkLockAccessory, Accessory);
-    copyInherit(WinkLightAccessory, Accessory);
-    copyInherit(WinkSwitchAccessory, Accessory);
-    copyInherit(WinkGarageDoorAccessory, Accessory);
-    copyInherit(WinkOutletAccessory, Accessory);
-    copyInherit(WinkSmokeDetectorAccessory, Accessory);
-    copyInherit(WinkThermostatAccessory, Accessory);
-    copyInherit(WinkAirConditionerAccessory, Accessory);
-    copyInherit(WinkSensorAccessory, Accessory);
-    copyInherit(WinkPropaneTankAccessory, Accessory);
 };
 
 function WinkPlatform(log, config) {
@@ -121,20 +112,20 @@ WinkPlatform.prototype = {
                         //Get Device Type
                         //NEWMODULE: Add Appropriate Lines Here
                         if (device.light_bulb_id !== undefined)
-                            accessory = new WinkLightAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkLightAccessory(that, device);
 
                         else if (device.garage_door_id !== undefined)
-                            accessory = new WinkGarageDoorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkGarageDoorAccessory(that, device);
 
                         else if (device.lock_id !== undefined)
-                            accessory = new WinkLockAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkLockAccessory(that, device);
 
                         else if (device.binary_switch_id !== undefined)
-                            accessory = new WinkSwitchAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkSwitchAccessory(that, device);
 
                         else if (device.powerstrip_id !== undefined) {
                             for (var j = 0; j < device.outlets.length; j++) {
-                                accessory = new WinkOutletAccessory(that, device.outlets[j], Service, Characteristic, Accessory, uuid);
+                                accessory = new WinkOutletAccessory(that, device.outlets[j]);
                                 if (accessory != undefined) {
                                     that.deviceLookup[accessory.deviceId] = accessory;
                                     foundAccessories.push(accessory);
@@ -143,19 +134,19 @@ WinkPlatform.prototype = {
                             }
 
                         } else if (device.smoke_detector_id !== undefined)
-                            accessory = new WinkSmokeDetectorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkSmokeDetectorAccessory(that, device);
 
                         else if (device.thermostat_id !== undefined)
-                            accessory = new WinkThermostatAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkThermostatAccessory(that, device);
 
                         else if (device.air_conditioner_id !== undefined)
-                            accessory = new WinkAirConditionerAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkAirConditionerAccessory(that, device);
 
                         else if (device.sensor_pod_id !== undefined)
-                            accessory = new WinkSensorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkSensorAccessory(that, device);
 
 						else if (device.propane_tank_id !== undefined)
-                            accessory = new WinkPropaneTankAccessory(that, device, Service, Characteristic, Accessory, uuid);
+                            accessory = new WinkPropaneTankAccessory(that, device);
 
                         //These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it 
                         //with a HomeKit service yet.
@@ -191,99 +182,5 @@ WinkPlatform.prototype = {
                 });
             }
         });
-    },
-    UpdateWinkProperty_noFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
-        this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
-        if (WinkAccessory.device.desired_state == undefined) {
-            callback(Error("Unsupported"));
-            return;
-        };
-
-
-        var myvariable = {
-            "desired_state": {}
-        };
-
-        if (sProperty instanceof Array) {
-            for (var i = 0; i < sProperty.length; i++) {
-                myvariable.desired_state[sProperty[i]] = sTarget[i];
-            }
-        } else {
-            if (WinkAccessory.device.desired_state[sProperty] == undefined) {
-                callback(Error("Unsupported"));
-                return;
-            };
-            myvariable.desired_state[sProperty] = sTarget;
-        }
-
-
-        WinkAccessory.control.update(myvariable, callback);
-
-    },
-    UpdateWinkProperty_withFeedback: function(WinkAccessory, callback, sProperty, sTarget) {
-        this.log("Changing target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
-        if (WinkAccessory.device.desired_state == undefined) {
-            callback(Error("Unsupported"));
-            return;
-        };
-        if (WinkAccessory.device.desired_state[sProperty] == undefined) {
-            callback(Error("Unsupported"));
-            return;
-        };
-
-        var myvariable = {
-            "desired_state": {}
-        };
-        myvariable.desired_state[sProperty] = sTarget;
-        var that = this;
-        var update = function(retry) {
-            WinkAccessory.control.update(myvariable,
-                function(res) {
-                    var err = WinkAccessory.handleResponse(res);
-                    if (!err) {
-                        that.refreshUntil(WinkAccessory, 5,
-                            function(sProperty) {
-                                return WinkAccessory.device.last_reading[sProperty] == WinkAccessory.device.desired_state[sProperty];
-                            },
-                            function(completed, device, sProperty) {
-                                if (completed) {
-                                    that.log("Successfully changed target property '" + sProperty + "' of the " + WinkAccessory.device.device_group + " called " + WinkAccessory.device.name + " to " + sTarget);
-                                } else if (retry) {
-                                    that.log("Unable to determine if update was successful. Retrying update.");
-                                    retry();
-                                } else {
-                                    that.log("Unable to determine if update was successful.");
-                                }
-                            }, 1000, 500, sProperty);
-                    }
-                    if (callback) {
-                        callback(err);
-                        callback = null;
-                    }
-                });
-        };
-        update(update);
-    },
-    refreshUntil: function(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty) {
-        if (!interval) {
-            interval = 500;
-        }
-        if (!incrementInterval) {
-            incrementInterval = 500;
-        }
-        setTimeout(function() {
-            that.control.refresh(function() {
-                if (predicate == undefined || predicate(sProperty) == true) {
-                    if (callback) callback(true, that.device, sProperty);
-                } else if (maxTimes > 0) {
-                    maxTimes = maxTimes - 1;
-                    interval += incrementInterval;
-                    that.platform.refreshUntil(that, maxTimes, predicate, callback, interval, incrementInterval, sProperty);
-                } else {
-                    if (callback) callback(false, that.device, sProperty);
-                }
-            });
-        }, interval);
     }
-
 };

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var WinkSmokeDetectorAccessory = require('./accessories/smoke_detectors');
 var WinkThermostatAccessory = require('./accessories/thermostats');
 var WinkAirConditionerAccessory = require('./accessories/air_conditioners');
 var WinkSensorAccessory = require('./accessories/sensor_pods');
+var WinkPropaneTankAccessory = require('./accessories/propane_tanks');
 
 process.env.WINK_NO_CACHE = true;
 
@@ -43,6 +44,7 @@ module.exports = function(homebridge) {
     copyInherit(WinkThermostatAccessory, Accessory);
     copyInherit(WinkAirConditionerAccessory, Accessory);
     copyInherit(WinkSensorAccessory, Accessory);
+    copyInherit(WinkPropaneTankAccessory, Accessory);
 };
 
 function WinkPlatform(log, config) {
@@ -81,7 +83,7 @@ WinkPlatform.prototype = {
                 for (var i = 0; i < devices.data.length; i++) {
                     var device = devices.data[i];
                     //NEWMODULE: Add the id here. I'm planning to redesign this section.
-                    var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | ""];
+                    var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | device.propane_tank_id | ""];
                     if (accessory != undefined) {
                         accessory.device = device;
                         accessory.loadData();
@@ -151,6 +153,9 @@ WinkPlatform.prototype = {
 
                         else if (device.sensor_pod_id !== undefined)
                             accessory = new WinkSensorAccessory(that, device, Service, Characteristic, Accessory, uuid);
+
+						else if (device.propane_tank_id !== undefined)
+                            accessory = new WinkPropaneTankAccessory(that, device, Service, Characteristic, Accessory, uuid);
 
                         //These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it 
                         //with a HomeKit service yet.

--- a/index.js
+++ b/index.js
@@ -17,170 +17,170 @@ var WinkAirConditionerAccessory;
 var WinkSensorAccessory;
 var WinkPropaneTankAccessory;
 
-module.exports = function(homebridge) {
-    Service = homebridge.hap.Service;
-    Characteristic = homebridge.hap.Characteristic;
-    Accessory = homebridge.hap.Accessory;
-    uuid = homebridge.hap.uuid;
+module.exports = function (homebridge) {
+	Service = homebridge.hap.Service;
+	Characteristic = homebridge.hap.Characteristic;
+	Accessory = homebridge.hap.Accessory;
+	uuid = homebridge.hap.uuid;
 
-    WinkAccessory = require('./lib/wink-accessory')(Accessory, Service, Characteristic, uuid);
-    WinkLockAccessory = require('./accessories/locks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkLightAccessory = require('./accessories/light_bulbs')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkSwitchAccessory = require('./accessories/binary_switches')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkGarageDoorAccessory = require('./accessories/garage_doors')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkOutletAccessory = require('./accessories/outlets')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkSmokeDetectorAccessory = require('./accessories/smoke_detectors')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkThermostatAccessory = require('./accessories/thermostats')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkAirConditionerAccessory = require('./accessories/air_conditioners')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkSensorAccessory = require('./accessories/sensor_pods')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-    WinkPropaneTankAccessory = require('./accessories/propane_tanks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkAccessory = require('./lib/wink-accessory')(Accessory, Service, Characteristic, uuid);
+	WinkLockAccessory = require('./accessories/locks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkLightAccessory = require('./accessories/light_bulbs')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkSwitchAccessory = require('./accessories/binary_switches')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkGarageDoorAccessory = require('./accessories/garage_doors')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkOutletAccessory = require('./accessories/outlets')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkSmokeDetectorAccessory = require('./accessories/smoke_detectors')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkThermostatAccessory = require('./accessories/thermostats')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkAirConditionerAccessory = require('./accessories/air_conditioners')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkSensorAccessory = require('./accessories/sensor_pods')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	WinkPropaneTankAccessory = require('./accessories/propane_tanks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
 
-    homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
+	homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
 };
 
 function WinkPlatform(log, config) {
-    // Load Wink Authentication From Config File
-    this.client_id = config["client_id"];
-    this.client_secret = config["client_secret"];
+	// Load Wink Authentication From Config File
+	this.client_id = config["client_id"];
+	this.client_secret = config["client_secret"];
 
-    this.username = config["username"];
-    this.password = config["password"];
+	this.username = config["username"];
+	this.password = config["password"];
 
-    // Load Groups or IDs that should be hidden from the Config File.
-    this.hidegroups = config["hide_groups"];
-    this.hideids = config["hide_ids"];
-    if (this.hidegroups == undefined) this.hidegroups = [];
-    if (this.hideids == undefined) this.hideids = [];
+	// Load Groups or IDs that should be hidden from the Config File.
+	this.hidegroups = config["hide_groups"];
+	this.hideids = config["hide_ids"];
+	if (this.hidegroups == undefined) this.hidegroups = [];
+	if (this.hideids == undefined) this.hideids = [];
 
-    // If this is true then devices that the Wink hub cannot communicate with will not be registered.
-    // In addition, any devices that lose communication will be unregistered which will allow HomeKit to know the device is not accessible.
-    this.unregister_disconnected = config["unregister_disconnected"] | false;
+	// If this is true then devices that the Wink hub cannot communicate with will not be registered.
+	// In addition, any devices that lose communication will be unregistered which will allow HomeKit to know the device is not accessible.
+	this.unregister_disconnected = config["unregister_disconnected"] | false;
 
-    //For Temperatures, what Display unit should we report (C or F)
-    this.temperature_unit = config["temperature_unit"];
-    if (this.temperature_unit === undefined) this.temperature_unit = "F";
+	//For Temperatures, what Display unit should we report (C or F)
+	this.temperature_unit = config["temperature_unit"];
+	if (this.temperature_unit === undefined) this.temperature_unit = "F";
 
-    this.log = log;
-    this.deviceLookup = {};
+	this.log = log;
+	this.deviceLookup = {};
 }
 
 WinkPlatform.prototype = {
-    reloadData: function(callback) {
-        //This is called when we need to refresh all Wink device information.
-        this.log("Refreshing Wink Data");
-        var that = this;
-        wink.user().devices(function(devices) { //TODO: Add the ability to detect new devices and unregister newly disconnected devices.
-            if (devices && devices.data && devices.data instanceof Array) {
-                for (var i = 0; i < devices.data.length; i++) {
-                    var device = devices.data[i];
-                    //NEWMODULE: Add the id here. I'm planning to redesign this section.
-                    var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | device.propane_tank_id | ""];
-                    if (accessory != undefined) {
-                        accessory.device = device;
-                        accessory.loadData();
-                    }
-                }
-            }
-            if (callback) callback();
-        });
-    },
-    accessories: function(callback) {
-        this.log("Fetching Wink devices.");
+	reloadData: function (callback) {
+		//This is called when we need to refresh all Wink device information.
+		this.log("Refreshing Wink Data");
+		var that = this;
+		wink.user().devices(function (devices) { //TODO: Add the ability to detect new devices and unregister newly disconnected devices.
+			if (devices && devices.data && devices.data instanceof Array) {
+				for (var i = 0; i < devices.data.length; i++) {
+					var device = devices.data[i];
+					//NEWMODULE: Add the id here. I'm planning to redesign this section.
+					var accessory = that.deviceLookup[device.lock_id | device.light_bulb_id | device.binary_switch_id | device.garage_door_id | device.outlet_id | device.smoke_detector_id | device.thermostat_id | device.air_conditioner_id | device.sensor_pod_id | device.propane_tank_id | ""];
+					if (accessory != undefined) {
+						accessory.device = device;
+						accessory.loadData();
+					}
+				}
+			}
+			if (callback) callback();
+		});
+	},
+	accessories: function (callback) {
+		this.log("Fetching Wink devices.");
 
-        var that = this;
-        var foundAccessories = [];
-        this.deviceLookup = {};
+		var that = this;
+		var foundAccessories = [];
+		this.deviceLookup = {};
 
-        var refreshLoop = function() {
-            setInterval(that.reloadData.bind(that), 30000);
-        };
+		var refreshLoop = function () {
+			setInterval(that.reloadData.bind(that), 30000);
+		};
 
-        wink.init({
-            "client_id": this.client_id,
-            "client_secret": this.client_secret,
-            "username": this.username,
-            "password": this.password
-        }, function(auth_return) {
-            if (auth_return === undefined) {
-                that.log("There was a problem authenticating with Wink.");
-            } else {
-                // success
-                wink.user().devices(function(devices) {
-                    for (var i = 0; i < devices.data.length; i++) {
-                        var device = devices.data[i];
-                        var accessory = null;
-                        //Get Device Type
-                        //NEWMODULE: Add Appropriate Lines Here
-                        if (device.light_bulb_id !== undefined)
-                            accessory = new WinkLightAccessory(that, device);
+		wink.init({
+			"client_id": this.client_id,
+			"client_secret": this.client_secret,
+			"username": this.username,
+			"password": this.password
+		}, function (auth_return) {
+			if (auth_return === undefined) {
+				that.log("There was a problem authenticating with Wink.");
+			} else {
+				// success
+				wink.user().devices(function (devices) {
+					for (var i = 0; i < devices.data.length; i++) {
+						var device = devices.data[i];
+						var accessory = null;
+						//Get Device Type
+						//NEWMODULE: Add Appropriate Lines Here
+						if (device.light_bulb_id !== undefined)
+							accessory = new WinkLightAccessory(that, device);
 
-                        else if (device.garage_door_id !== undefined)
-                            accessory = new WinkGarageDoorAccessory(that, device);
+						else if (device.garage_door_id !== undefined)
+							accessory = new WinkGarageDoorAccessory(that, device);
 
-                        else if (device.lock_id !== undefined)
-                            accessory = new WinkLockAccessory(that, device);
+						else if (device.lock_id !== undefined)
+							accessory = new WinkLockAccessory(that, device);
 
-                        else if (device.binary_switch_id !== undefined)
-                            accessory = new WinkSwitchAccessory(that, device);
+						else if (device.binary_switch_id !== undefined)
+							accessory = new WinkSwitchAccessory(that, device);
 
-                        else if (device.powerstrip_id !== undefined) {
-                            for (var j = 0; j < device.outlets.length; j++) {
-                                accessory = new WinkOutletAccessory(that, device.outlets[j]);
-                                if (accessory != undefined) {
-                                    that.deviceLookup[accessory.deviceId] = accessory;
-                                    foundAccessories.push(accessory);
-                                }
-                                accessory = undefined;
-                            }
+						else if (device.powerstrip_id !== undefined) {
+							for (var j = 0; j < device.outlets.length; j++) {
+								accessory = new WinkOutletAccessory(that, device.outlets[j]);
+								if (accessory != undefined) {
+									that.deviceLookup[accessory.deviceId] = accessory;
+									foundAccessories.push(accessory);
+								}
+								accessory = undefined;
+							}
 
-                        } else if (device.smoke_detector_id !== undefined)
-                            accessory = new WinkSmokeDetectorAccessory(that, device);
+						} else if (device.smoke_detector_id !== undefined)
+							accessory = new WinkSmokeDetectorAccessory(that, device);
 
-                        else if (device.thermostat_id !== undefined)
-                            accessory = new WinkThermostatAccessory(that, device);
+						else if (device.thermostat_id !== undefined)
+							accessory = new WinkThermostatAccessory(that, device);
 
-                        else if (device.air_conditioner_id !== undefined)
-                            accessory = new WinkAirConditionerAccessory(that, device);
+						else if (device.air_conditioner_id !== undefined)
+							accessory = new WinkAirConditionerAccessory(that, device);
 
-                        else if (device.sensor_pod_id !== undefined)
-                            accessory = new WinkSensorAccessory(that, device);
+						else if (device.sensor_pod_id !== undefined)
+							accessory = new WinkSensorAccessory(that, device);
 
 						else if (device.propane_tank_id !== undefined)
-                            accessory = new WinkPropaneTankAccessory(that, device);
+							accessory = new WinkPropaneTankAccessory(that, device);
 
-                        //These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it 
-                        //with a HomeKit service yet.
-                        else if (device.manufacturer_device_model = "wink_hub")
-                            that.log("Device Ignored Not In HomeKit - Group hubs, ID " + device.hub_id + ", Name " + device.name);
-                        else if (device.remote_id !== undefined)
-                            that.log("Device Ignored Not In HomeKit - Group remotes, ID " + device.remote_id + ", Name " + device.name);
-                        else if (device.unknown_device_id !== undefined)
-                            that.log("Device Ignored Not In HomeKit - Group unknown_devices, ID " + device.unknown_device_id + ", Name " + device.name);
-                        else if (device.eggtray_id !== undefined)
-                            that.log("Device Ignored Not In HomeKit - Group eggtrays, ID " + device.eggtray_id + ", Name " + device.name);
-                        else if (device.piggy_bank_id !== undefined)
-                            that.log("Device Ignored Not In HomeKit - Group piggy_banks, ID " + device.piggy_bank_id + ", Name " + device.name);
+						//These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it
+						//with a HomeKit service yet.
+						else if (device.manufacturer_device_model = "wink_hub")
+							that.log("Device Ignored Not In HomeKit - Group hubs, ID " + device.hub_id + ", Name " + device.name);
+						else if (device.remote_id !== undefined)
+							that.log("Device Ignored Not In HomeKit - Group remotes, ID " + device.remote_id + ", Name " + device.name);
+						else if (device.unknown_device_id !== undefined)
+							that.log("Device Ignored Not In HomeKit - Group unknown_devices, ID " + device.unknown_device_id + ", Name " + device.name);
+						else if (device.eggtray_id !== undefined)
+							that.log("Device Ignored Not In HomeKit - Group eggtrays, ID " + device.eggtray_id + ", Name " + device.name);
+						else if (device.piggy_bank_id !== undefined)
+							that.log("Device Ignored Not In HomeKit - Group piggy_banks, ID " + device.piggy_bank_id + ", Name " + device.name);
 
-                        else that.log("Unknown Device Group: " + JSON.stringify(device));
+						else that.log("Unknown Device Group: " + JSON.stringify(device));
 
-                        if (accessory != undefined) {
-                            if (that.hidegroups.indexOf(accessory.deviceGroup) >= 0) { //Make sure the group isn't supposed to be hidden
-                                that.log("Device Ignored By Group - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
-                            } else if (that.hideids.indexOf(accessory.deviceId) >= 0) { //Make sure the ID isn't supposed to be hidden
-                                that.log("Device Ignored By ID - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
-                            } else if (that.unregister_disconnected && !accessory.device.last_reading.connection) {
-                                that.log("Device Ignored By Disconnection - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
-                            } else {
-                                that.log("Device Added - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
-                                that.deviceLookup[accessory.deviceId] = accessory;
-                                foundAccessories.push(accessory);
-                            }
-                        }
-                    }
-                    refreshLoop();
-                    callback(foundAccessories);
-                });
-            }
-        });
-    }
+						if (accessory != undefined) {
+							if (that.hidegroups.indexOf(accessory.deviceGroup) >= 0) { //Make sure the group isn't supposed to be hidden
+								that.log("Device Ignored By Group - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+							} else if (that.hideids.indexOf(accessory.deviceId) >= 0) { //Make sure the ID isn't supposed to be hidden
+								that.log("Device Ignored By ID - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+							} else if (that.unregister_disconnected && !accessory.device.last_reading.connection) {
+								that.log("Device Ignored By Disconnection - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+							} else {
+								that.log("Device Added - Group " + accessory.deviceGroup + ", ID " + accessory.deviceId + ", Name " + accessory.name);
+								that.deviceLookup[accessory.deviceId] = accessory;
+								foundAccessories.push(accessory);
+							}
+						}
+					}
+					refreshLoop();
+					callback(foundAccessories);
+				});
+			}
+		});
+	}
 };

--- a/lib/wink-accessory.js
+++ b/lib/wink-accessory.js
@@ -2,7 +2,7 @@ var wink = require('wink-js');
 var inherits = require('util').inherits;
 var Service, Characteristic, Accessory, uuid;
 
-module.exports = function(oAccessory, oService, oCharacteristic, ouuid) {
+module.exports = function (oAccessory, oService, oCharacteristic, ouuid) {
 	if (oAccessory) {
 		Accessory = oAccessory;
 		Service = oService;
@@ -138,11 +138,11 @@ var updatePropertyWithoutFeedback = function (callback, sProperty, sTarget) {
 
 };
 
-var getServices = function() {
+var getServices = function () {
 	return this.services;
 };
 
-var handleResponse = function(res) {
+var handleResponse = function (res) {
 	if (!res) {
 		return Error("No response from Wink");
 	} else if (res.errors && res.errors.length > 0) {

--- a/lib/wink-accessory.js
+++ b/lib/wink-accessory.js
@@ -1,0 +1,154 @@
+var wink = require('wink-js');
+var inherits = require('util').inherits;
+var Service, Characteristic, Accessory, uuid;
+
+module.exports = function(oAccessory, oService, oCharacteristic, ouuid) {
+	if (oAccessory) {
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
+
+		inherits(WinkAccessory, Accessory);
+		WinkAccessory.prototype.updatePropertyWithFeedback = updatePropertyWithFeedback;
+		WinkAccessory.prototype.updatePropertyWithoutFeedback = updatePropertyWithoutFeedback;
+		WinkAccessory.prototype.refreshUntil = refreshUntil;
+		WinkAccessory.prototype.getServices = getServices;
+		WinkAccessory.prototype.handleResponse = handleResponse;
+	}
+	return WinkAccessory;
+};
+module.exports.WinkAccessory = WinkAccessory;
+
+function WinkAccessory(platform, device, deviceId) {
+	this.platform = platform;
+	this.device = device;
+	this.deviceId = deviceId;
+	this.name = device.name;
+	this.log = platform.log;
+
+	var idKey = 'hbdev:wink:' + this.deviceGroup + ':' + this.deviceId;
+	var id = uuid.generate(idKey);
+	Accessory.call(this, this.name, id);
+	this.uuid_base = id;
+
+	this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+
+	// set some basic properties (these values are arbitrary and setting them is optional)
+	this
+		.getService(Service.AccessoryInformation)
+		.setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
+		.setCharacteristic(Characteristic.Model, this.device.model_name);
+}
+
+var refreshUntil = function (maxTimes, predicate, callback, interval, incrementInterval, sProperty) {
+	var that = this;
+	if (!interval) {
+		interval = 500;
+	}
+	if (!incrementInterval) {
+		incrementInterval = 500;
+	}
+	setTimeout(function () {
+		that.control.refresh(function () {
+			if (predicate == undefined || predicate(sProperty) == true) {
+				if (callback) callback(true, that.device, sProperty);
+			} else if (maxTimes > 0) {
+				maxTimes = maxTimes - 1;
+				interval += incrementInterval;
+				that.refreshUntil(maxTimes, predicate, callback, interval, incrementInterval, sProperty);
+			} else {
+				if (callback) callback(false, that.device, sProperty);
+			}
+		});
+	}, interval);
+};
+
+var updatePropertyWithFeedback = function (callback, sProperty, sTarget) {
+
+	this.log("Changing target property '" + sProperty + "' of the " + this.device.device_group + " called " + this.device.name + " to " + sTarget);
+	if (this.device.desired_state == undefined) {
+		callback(Error("Unsupported"));
+		return;
+	}
+
+	if (this.device.desired_state[sProperty] == undefined) {
+		callback(Error("Unsupported"));
+		return;
+	}
+
+	var data = {
+		"desired_state": {}
+	};
+	data.desired_state[sProperty] = sTarget;
+	var that = this;
+	var update = function (retry) {
+		that.control.update(data,
+			function (res) {
+				var err = that.handleResponse(res);
+				if (!err) {
+					that.refreshUntil(5,
+						function (sProperty) {
+							return that.device.last_reading[sProperty] == that.device.desired_state[sProperty];
+						},
+						function (completed, device, sProperty) {
+							if (completed) {
+								that.log("Successfully changed target property '" + sProperty + "' of the " + that.device.device_group + " called " + that.device.name + " to " + sTarget);
+							} else if (retry) {
+								that.log("Unable to determine if update was successful. Retrying update.");
+								retry();
+							} else {
+								that.log("Unable to determine if update was successful.");
+							}
+						}, 1000, 500, sProperty);
+				}
+				if (callback) {
+					callback(err);
+					callback = null;
+				}
+			});
+	};
+	update(update);
+};
+
+var updatePropertyWithoutFeedback = function (callback, sProperty, sTarget) {
+	this.log("Changing target property '" + sProperty + "' of the " + this.device.device_group + " called " + this.device.name + " to " + sTarget);
+	if (this.device.desired_state == undefined) {
+		callback(Error("Unsupported"));
+		return;
+	}
+
+	var update = {
+		"desired_state": {}
+	};
+
+	if (sProperty instanceof Array) {
+		for (var i = 0; i < sProperty.length; i++) {
+			update.desired_state[sProperty[i]] = sTarget[i];
+		}
+	} else {
+		if (this.device.desired_state[sProperty] == undefined) {
+			callback(Error("Unsupported"));
+			return;
+		}
+		update.desired_state[sProperty] = sTarget;
+	}
+
+	this.control.update(update, callback);
+
+};
+
+var getServices = function() {
+	return this.services;
+};
+
+var handleResponse = function(res) {
+	if (!res) {
+		return Error("No response from Wink");
+	} else if (res.errors && res.errors.length > 0) {
+		return res.errors[0];
+	} else if (res.data) {
+		this.device = res.data;
+		if (this.loadData) this.loadData();
+	}
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-legacy-plugins",
   "description": "Legacy plugins for homebridge: https://github.com/nfarina/homebridge",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/nfarina/homebridge-legacy-plugins.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-legacy-plugins",
   "description": "Legacy plugins for homebridge: https://github.com/nfarina/homebridge",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/nfarina/homebridge-legacy-plugins.git"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "homebridge-legacy-plugins",
+  "name": "homebridge-wink",
   "description": "Legacy plugins for homebridge: https://github.com/nfarina/homebridge",
   "version": "0.0.5",
   "repository": {
     "type": "git",
-    "url": "git://github.com/nfarina/homebridge-legacy-plugins.git"
+    "url": "git://github.com/nfarina/homebridge-wink.git"
   },
   "license": "ISC",
   "preferGlobal": true,

--- a/package.json
+++ b/package.json
@@ -1,21 +1,22 @@
 {
   "name": "homebridge-wink",
   "description": "Legacy plugins for homebridge: https://github.com/nfarina/homebridge",
-  "version": "0.0.5",
+  "version": "0.0.7",
   "repository": {
     "type": "git",
-    "url": "git://github.com/nfarina/homebridge-wink.git"
+    "url": "git://github.com/kraigm/homebridge-wink.git"
   },
   "license": "ISC",
   "preferGlobal": true,
   "keywords": [
-    "homebridge-plugin"
+    "homebridge-plugin",
+	"wink"
   ],
   "engines": {
     "node": ">=0.12.0",
     "homebridge": ">=0.2.5"
   },
   "dependencies": {
-    "wink-js": "0.0.5"
+    "wink-js": "0.0.9"
   }
 }


### PR DESCRIPTION
I used the WinkLockAccessory as a base class of how to work around the issue of the wink-js missing most of the group types. The one downside is that it currently doesn't support that "instant" lock update when triggering a lock.
I then pulled each accessory type out into it's own file for easier management. Currently it covers Lights, Locks, Garage Door and basic Binary Switches.
I also listed all available device types to work as a simple checklist and reveal what still hasn't been done.
With this framework, it makes it very simple to add new device types.

Installation is as simple as placing the index.js and accessories folder into an existing installation's home bridge-wink folder for testing. 