### PR TITLE
Fixes Siri impatience and Colored Lights

### DIFF
--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -28,36 +28,50 @@ function WinkGarageDoorAccessory(platform, device) {
 	var that = this;
 
 	//Items specific to Garage Doors:
-	this
-		.addService(Service.GarageDoorOpener)
-		.getCharacteristic(Characteristic.TargetDoorState)
-		.on('get', function (callback) {
-			if (that.device.desired_state.position == 0)
-				callback(null, Characteristic.TargetDoorState.CLOSED);
-			else if (that.device.desired_state.position == 1)
-				callback(null, Characteristic.TargetDoorState.OPEN);
-		})
-		.on('set', function (value, callback) {
-			if (value == Characteristic.TargetDoorState.OPEN)
-				that.updateWinkProperty(callback, "position", 1);
-			else if (value == Characteristic.TargetDoorState.CLOSED)
-				that.updateWinkProperty(callback, "position", 0);
-		});
+	if (platform.garage_lowsecurity) {
+		//Low Security Mode (Siri with locked phone )
+		this
+			.addService(Service.Switch)
+			.getCharacteristic(Characteristic.On)
+			.on('get', function (callback) {
+				callback(null, (that.device.last_reading.position==1));
+			})
+			.on('set', function (value, callback) {
+				if (value)
+					that.updateWinkProperty(callback, "position", 1);
+				else
+					that.updateWinkProperty(callback, "position", 0);
+			});
 
-	this
-		.getService(Service.GarageDoorOpener)
-		.getCharacteristic(Characteristic.CurrentDoorState)
-		.on('get', function (callback) {
-			if (that.device.last_reading.position == 0)
-				callback(null, Characteristic.CurrentDoorState.CLOSED);
-			else if (that.device.last_reading.position == 1)
-				callback(null, Characteristic.CurrentDoorState.OPEN);
-		});
-
-	this
-		.getService(Service.GarageDoorOpener)
-		.setCharacteristic(Characteristic.ObstructionDetected, false);
-
+	} else {
+		this
+			.addService(Service.GarageDoorOpener)
+			.getCharacteristic(Characteristic.TargetDoorState)
+			.on('get', function (callback) {
+				if (that.device.desired_state.position == 0)
+					callback(null, Characteristic.TargetDoorState.CLOSED);
+				else if (that.device.desired_state.position == 1)
+					callback(null, Characteristic.TargetDoorState.OPEN);
+			})
+			.on('set', function (value, callback) {
+				if (value == Characteristic.TargetDoorState.OPEN)
+					that.updateWinkProperty(callback, "position", 1);
+				else if (value == Characteristic.TargetDoorState.CLOSED)
+					that.updateWinkProperty(callback, "position", 0);
+			});
+		this
+			.getService(Service.GarageDoorOpener)
+			.getCharacteristic(Characteristic.CurrentDoorState)
+			.on('get', function (callback) {
+				if (that.device.last_reading.position == 0)
+					callback(null, Characteristic.CurrentDoorState.CLOSED);
+				else if (that.device.last_reading.position == 1)
+					callback(null, Characteristic.CurrentDoorState.OPEN);
+			});
+		this
+			.getService(Service.GarageDoorOpener)
+			.setCharacteristic(Characteristic.ObstructionDetected, false);
+	}
 	//Track the Battery Level
 	if (that.device.last_reading.battery !== undefined) {
 		this.addService(Service.BatteryService)
@@ -84,12 +98,18 @@ function WinkGarageDoorAccessory(platform, device) {
 }
 
 var loadData = function () {
-	this.getService(Service.GarageDoorOpener)
-		.getCharacteristic(Characteristic.CurrentDoorState)
-		.getValue();
-	this.getService(Service.GarageDoorOpener)
-		.getCharacteristic(Characteristic.TargetDoorState)
-		.getValue();
+	if (this.platform.garage_lowsecurity) {
+		this.getService(Service.Switch)
+			.getCharacteristic(Characteristic.On)
+			.getValue();
+	} else {
+		this.getService(Service.GarageDoorOpener)
+			.getCharacteristic(Characteristic.CurrentDoorState)
+			.getValue();
+		this.getService(Service.GarageDoorOpener)
+			.getCharacteristic(Characteristic.TargetDoorState)
+			.getValue();
+	}
 	if (this.device.last_reading.battery !== undefined) {
 		this.getService(Service.BatteryService)
 			.getCharacteristic(Characteristic.BatteryLevel)

--- a/accessories/garage_doors.js
+++ b/accessories/garage_doors.js
@@ -28,50 +28,36 @@ function WinkGarageDoorAccessory(platform, device) {
 	var that = this;
 
 	//Items specific to Garage Doors:
-	if (platform.garage_lowsecurity) {
-		//Low Security Mode (Siri with locked phone )
-		this
-			.addService(Service.Switch)
-			.getCharacteristic(Characteristic.On)
-			.on('get', function (callback) {
-				callback(null, (that.device.last_reading.position==1));
-			})
-			.on('set', function (value, callback) {
-				if (value)
-					that.updateWinkProperty(callback, "position", 1);
-				else
-					that.updateWinkProperty(callback, "position", 0);
-			});
+	this
+		.addService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.TargetDoorState)
+		.on('get', function (callback) {
+			if (that.device.desired_state.position == 0)
+				callback(null, Characteristic.TargetDoorState.CLOSED);
+			else if (that.device.desired_state.position == 1)
+				callback(null, Characteristic.TargetDoorState.OPEN);
+		})
+		.on('set', function (value, callback) {
+			if (value == Characteristic.TargetDoorState.OPEN)
+				that.updateWinkProperty(callback, "position", 1);
+			else if (value == Characteristic.TargetDoorState.CLOSED)
+				that.updateWinkProperty(callback, "position", 0);
+		});
 
-	} else {
-		this
-			.addService(Service.GarageDoorOpener)
-			.getCharacteristic(Characteristic.TargetDoorState)
-			.on('get', function (callback) {
-				if (that.device.desired_state.position == 0)
-					callback(null, Characteristic.TargetDoorState.CLOSED);
-				else if (that.device.desired_state.position == 1)
-					callback(null, Characteristic.TargetDoorState.OPEN);
-			})
-			.on('set', function (value, callback) {
-				if (value == Characteristic.TargetDoorState.OPEN)
-					that.updateWinkProperty(callback, "position", 1);
-				else if (value == Characteristic.TargetDoorState.CLOSED)
-					that.updateWinkProperty(callback, "position", 0);
-			});
-		this
-			.getService(Service.GarageDoorOpener)
-			.getCharacteristic(Characteristic.CurrentDoorState)
-			.on('get', function (callback) {
-				if (that.device.last_reading.position == 0)
-					callback(null, Characteristic.CurrentDoorState.CLOSED);
-				else if (that.device.last_reading.position == 1)
-					callback(null, Characteristic.CurrentDoorState.OPEN);
-			});
-		this
-			.getService(Service.GarageDoorOpener)
-			.setCharacteristic(Characteristic.ObstructionDetected, false);
-	}
+	this
+		.getService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.CurrentDoorState)
+		.on('get', function (callback) {
+			if (that.device.last_reading.position == 0)
+				callback(null, Characteristic.CurrentDoorState.CLOSED);
+			else if (that.device.last_reading.position == 1)
+				callback(null, Characteristic.CurrentDoorState.OPEN);
+		});
+
+	this
+		.getService(Service.GarageDoorOpener)
+		.setCharacteristic(Characteristic.ObstructionDetected, false);
+
 	//Track the Battery Level
 	if (that.device.last_reading.battery !== undefined) {
 		this.addService(Service.BatteryService)
@@ -98,18 +84,12 @@ function WinkGarageDoorAccessory(platform, device) {
 }
 
 var loadData = function () {
-	if (this.platform.garage_lowsecurity) {
-		this.getService(Service.Switch)
-			.getCharacteristic(Characteristic.On)
-			.getValue();
-	} else {
-		this.getService(Service.GarageDoorOpener)
-			.getCharacteristic(Characteristic.CurrentDoorState)
-			.getValue();
-		this.getService(Service.GarageDoorOpener)
-			.getCharacteristic(Characteristic.TargetDoorState)
-			.getValue();
-	}
+	this.getService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.CurrentDoorState)
+		.getValue();
+	this.getService(Service.GarageDoorOpener)
+		.getCharacteristic(Characteristic.TargetDoorState)
+		.getValue();
 	if (this.device.last_reading.battery !== undefined) {
 		this.getService(Service.BatteryService)
 			.getCharacteristic(Characteristic.BatteryLevel)

--- a/accessories/light_bulbs.js
+++ b/accessories/light_bulbs.js
@@ -4,6 +4,7 @@ var events = require('events');
 var eventEmitter = new events.EventEmitter();
 
 var WinkAccessory, Accessory, Service, Characteristic, uuid;
+var setH, setS, setB;
 
 /*
  *   Light Accessory
@@ -29,7 +30,11 @@ function WinkLightAccessory(platform, device) {
 	WinkAccessory.call(this, platform, device, device.light_bulb_id);
 
 	var that = this;
-
+	
+	this.hue = undefined;
+	this.saturation = undefined;
+	this.brightness = undefined;
+	
 	//Items specific to Light Bulbs Locks:
 	this
 		.addService(Service.Lightbulb)
@@ -46,27 +51,26 @@ function WinkLightAccessory(platform, device) {
 			.getService(Service.Lightbulb)
 			.getCharacteristic(Characteristic.Brightness)
 			.on('get', function (callback) {
-				callback(null, Math.floor(that.device.last_reading.brightness * 100));
+				that.brightness=Math.floor(that.device.last_reading.brightness * 100);
+				callback(null, that.brightness);
 			})
 			.on('set', function (value, callback) {
-				that.updateWinkProperty(callback, "brightness", value / 100);
+				that.brightness=value / 100;
+				that.updateWinkProperty(callback, "brightness", that.brightness);
 			});
-
-	if (that.device.desired_state.color_model != undefined)
-		that.updateWinkProperty(function () {
-			return 0;
-		}, "color_model", "hsb", true);
-
 
 	if (that.device.desired_state.hue !== undefined)
 		this
 			.getService(Service.Lightbulb)
 			.getCharacteristic(Characteristic.Hue)
 			.on('get', function (callback) {
-				callback(null, Math.floor(that.device.last_reading.hue * 360));
+				that.hue = Math.floor(that.device.last_reading.hue*360);
+				callback(null, that.hue);
 			})
 			.on('set', function (value, callback) {
-				that.updateWinkProperty(callback, "hue", value / 360);
+				that.hue = value/360;
+				that.updateWinkProperty(callback, ["hue","saturation","brightness","color_model"], 
+											[that.hue, that.saturation, that.brightness, 'hsb']);				
 			});
 
 	if (that.device.desired_state.saturation !== undefined)
@@ -74,10 +78,13 @@ function WinkLightAccessory(platform, device) {
 			.getService(Service.Lightbulb)
 			.getCharacteristic(Characteristic.Saturation)
 			.on('get', function (callback) {
-				callback(null, Math.floor(that.device.last_reading.saturation * 100));
+				that.saturation = Math.floor(that.device.last_reading.saturation*100);
+				callback(null, that.saturation);
 			})
 			.on('set', function (value, callback) {
-				that.updateWinkProperty(callback, "saturation", value / 100);
+				that.saturation = value/100;
+				that.updateWinkProperty(callback, ["hue","saturation","brightness","color_model"], 
+											[that.hue, that.saturation, that.brightness, 'hsb']);				
 			});
 
 	this.loadData();

--- a/accessories/sensor_pods.js
+++ b/accessories/sensor_pods.js
@@ -90,16 +90,36 @@ function WinkSensorAccessory(platform, device) {
 			});
 
 	//Open/Close Sensor
-	if (that.device.last_reading.opened !== undefined)
-		this
-			.addService(Service.Door)
-			.getCharacteristic(Characteristic.CurrentPosition)
-			.on('get', function (callback) {
-				if (that.device.last_reading.opened)
-					callback(null, 100);
-				else
-					callback(null, 0);
-			});
+	if (that.device.last_reading.opened !== undefined) {
+		if (platform.windowsensors.indexOf(that.deviceId) >= 0) {
+			this
+				.addService(Service.Window)
+				.getCharacteristic(Characteristic.CurrentPosition)
+				.on('get', function (callback) {
+					if (that.device.last_reading.opened)
+						callback(null, 100);
+					else
+						callback(null, 0);
+				});
+			this
+				.getService(Service.Window)
+				.setCharacteristic(Characteristic.PositionState, Characteristic.PositionState.STOPPED)			
+		} else {
+			this
+				.addService(Service.Door)
+				.getCharacteristic(Characteristic.CurrentPosition)
+				.on('get', function (callback) {
+					if (that.device.last_reading.opened)
+						callback(null, 100);
+					else
+						callback(null, 0);
+				});
+			this
+				.getService(Service.Door)
+				.setCharacteristic(Characteristic.PositionState, Characteristic.PositionState.STOPPED)
+		}
+	}
+
 
 
 	//Track the Battery Level
@@ -165,9 +185,16 @@ var loadData = function () {
 			.getValue();
 
 	//Open/Close Sensor
-	if (this.device.last_reading.opened !== undefined)
-		this
+	if (this.device.last_reading.opened !== undefined) {
+		if (this.platform.windowsensors.indexOf(this.deviceId) >= 0) 
+			this
+			.getService(Service.Window)
+			.getCharacteristic(Characteristic.CurrentPosition)
+			.getValue();
+		else
+			this
 			.getService(Service.Door)
 			.getCharacteristic(Characteristic.CurrentPosition)
 			.getValue();
+	}
 };

--- a/accessories/shades.js
+++ b/accessories/shades.js
@@ -1,0 +1,101 @@
+var inherits = require('util').inherits;
+
+var WinkAccessory, Accessory, Service, Characteristic, uuid;
+
+/*
+ *   Shade Accessory
+ */
+
+module.exports = function (oWinkAccessory, oAccessory, oService, oCharacteristic, ouuid) {
+	if (oWinkAccessory) {
+		WinkAccessory = oWinkAccessory;
+		Accessory = oAccessory;
+		Service = oService;
+		Characteristic = oCharacteristic;
+		uuid = ouuid;
+
+		inherits(WinkShadeAccessory, WinkAccessory);
+		WinkShadeAccessory.prototype.loadData = loadData;
+		WinkShadeAccessory.prototype.deviceGroup = 'shades';
+	}
+	return WinkShadeAccessory;
+};
+module.exports.WinkShadeAccessory = WinkShadeAccessory;
+
+function WinkShadeAccessory(platform, device) {
+	WinkAccessory.call(this, platform, device, device.shade_id);
+
+	var that = this;
+
+	//Items specific to Shades:
+	this
+		.addService(Service.WindowCovering)
+		.getCharacteristic(Characteristic.TargetPosition)
+		.on('get', function (callback) {
+			if (that.device.desired_state.position == 0)
+				callback(null, 0);
+			else if (that.device.desired_state.position == 1)
+				callback(null, 100);
+		})
+		.on('set', function (value, callback) {
+			if (value == 100)
+				that.updateWinkProperty(callback, "position", 1);
+			else if (value == 0)
+				that.updateWinkProperty(callback, "position", 0);
+		});
+
+	this
+		.getService(Service.WindowCovering)
+		.getCharacteristic(Characteristic.CurrentPosition)
+		.on('get', function (callback) {
+			if (that.device.last_reading.position == 0)
+				callback(null, 0);
+			else if (that.device.last_reading.position == 1)
+				callback(null, 100);
+		});
+
+	this
+		.getService(Service.WindowCovering)
+		.setCharacteristic(Characteristic.PositionState, Characteristic.PositionState.STOPPED)
+		
+	//Track the Battery Level
+	if (that.device.last_reading.battery !== undefined) {
+		this.addService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.on('get', function (callback) {
+				callback(null, Math.floor(that.device.last_reading.battery * 100));
+			});
+
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.on('get', function (callback) {
+				if (that.device.last_reading.battery < 0.25)
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+				else
+					callback(null, Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+			});
+
+		this.getService(Service.BatteryService)
+			.setCharacteristic(Characteristic.ChargingState, Characteristic.ChargingState.NOT_CHARGING);
+	}
+	//End Battery Level Tracking
+
+	this.loadData();
+}
+
+var loadData = function () {
+	this.getService(Service.WindowCovering)
+		.getCharacteristic(Characteristic.CurrentPosition)
+		.getValue();
+	this.getService(Service.WindowCovering)
+		.getCharacteristic(Characteristic.TargetPosition)
+		.getValue();
+	if (this.device.last_reading.battery !== undefined) {
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.BatteryLevel)
+			.getValue();
+		this.getService(Service.BatteryService)
+			.getCharacteristic(Characteristic.StatusLowBattery)
+			.getValue();
+	}
+};

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var WinkAirConditionerAccessory;
 var WinkSensorAccessory;
 var WinkPropaneTankAccessory;
 var WinkSirenAccessory;
+var WinkShadeAccessory;
 
 module.exports = function (homebridge) {
 	Service = homebridge.hap.Service;
@@ -36,7 +37,8 @@ module.exports = function (homebridge) {
 	WinkSensorAccessory = require('./accessories/sensor_pods')(WinkAccessory, Accessory, Service, Characteristic, uuid);
 	WinkPropaneTankAccessory = require('./accessories/propane_tanks')(WinkAccessory, Accessory, Service, Characteristic, uuid);
 	WinkSirenAccessory = require('./accessories/sirens')(WinkAccessory, Accessory, Service, Characteristic, uuid);
-
+	WinkShadeAccessory = require('./accessories/shades')(WinkAccessory, Accessory, Service, Characteristic, uuid);
+	
 	homebridge.registerPlatform("homebridge-wink", "Wink", WinkPlatform);
 };
 
@@ -61,6 +63,16 @@ function WinkPlatform(log, config) {
 	//For Temperatures, what Display unit should we report (C or F)
 	this.temperature_unit = config["temperature_unit"];
 	if (this.temperature_unit === undefined) this.temperature_unit = "F";
+
+	//Allows specific positional sensors to be treated as Windows instead of Doors
+	this.windowsensors = config["window_ids"];
+	if (this.windowsensors == undefined) this.windowsensors = [];
+
+	//This allows the garage to be represented as a switch.
+	//This is not secure because Siri will allow toggling it without unlocking the phone.
+	this.garage_lowsecurity = config["garage_lowsecurity"];
+	if (this.garage_lowsecurity == undefined) this.garage_lowsecurity = false;
+
 
 	this.log = log;
 	this.deviceLookup = {};
@@ -152,6 +164,9 @@ WinkPlatform.prototype = {
 
 						else if (device.siren_id !== undefined)
 							accessory = new WinkSirenAccessory(that, device);
+
+						else if (device.shade_id !== undefined)
+							accessory = new WinkShadeAccessory(that, device);
 
 						//These are here to prevent Unknown Device Groups in the logs when we know what the device is and can't represent it
 						//with a HomeKit service yet.

--- a/index.js
+++ b/index.js
@@ -68,12 +68,7 @@ function WinkPlatform(log, config) {
 	this.windowsensors = config["window_ids"];
 	if (this.windowsensors == undefined) this.windowsensors = [];
 
-	//This allows the garage to be represented as a switch.
-	//This is not secure because Siri will allow toggling it without unlocking the phone.
-	this.garage_lowsecurity = config["garage_lowsecurity"];
-	if (this.garage_lowsecurity == undefined) this.garage_lowsecurity = false;
-
-
+	
 	this.log = log;
 	this.deviceLookup = {};
 }

--- a/lib/wink-accessory.js
+++ b/lib/wink-accessory.js
@@ -32,12 +32,14 @@ function WinkAccessory(platform, device, deviceId) {
 	this.uuid_base = id;
 
 	this.control = wink.device_group(this.deviceGroup).device_id(this.deviceId);
+	var that = this;
 
 	// set some basic properties (these values are arbitrary and setting them is optional)
 	this
 		.getService(Service.AccessoryInformation)
 		.setCharacteristic(Characteristic.Manufacturer, this.device.device_manufacturer)
 		.setCharacteristic(Characteristic.Model, this.device.model_name);
+		
 }
 
 var refreshUntil = function (maxTimes, predicate, callback, interval, incrementInterval, sProperty) {
@@ -71,7 +73,14 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 		return;
 	}
 
-	if (this.device.desired_state[sProperty] == undefined) {
+	if (sProperty instanceof Array) {
+		for (var i = 0; i < sProperty.length; i++) {
+			if (this.device.desired_state[sProperty[i]] == undefined) {
+				callback(Error("Unsupported"));
+				return;
+			}
+		}
+	} else if (this.device.desired_state[sProperty] == undefined) {
 		callback(Error("Unsupported"));
 		return;
 	}
@@ -84,7 +93,19 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 	var data = {
 		"desired_state": {}
 	};
-	data.desired_state[sProperty] = sTarget;
+
+	if (sProperty instanceof Array) {
+		for (var i = 0; i < sProperty.length; i++) {
+			data.desired_state[sProperty[i]] = sTarget[i];
+		}
+	} else {
+		data.desired_state[sProperty] = sTarget;
+	}
+
+
+
+	if (callback) callback();
+
 	var that = this;
 	var update = function (retry) {
 		that.control.update(data,
@@ -93,7 +114,14 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 				if (!err) {
 					that.refreshUntil(8,
 						function (sProperty) {
-							return ((that.device.last_reading[sProperty] == that.device.desired_state[sProperty]) || bIgnoreFeedback);
+								if (sProperty instanceof Array) {
+									for (var i = 0; i < sProperty.length; i++) {
+										return ((that.device.last_reading[sProperty[i]] == that.device.desired_state[sProperty[i]]) || bIgnoreFeedback);
+									}
+								} else {
+									return ((that.device.last_reading[sProperty] == that.device.desired_state[sProperty]) || bIgnoreFeedback);
+								}
+							
 						},
 						function (completed, device, sProperty) {
 							if (completed) {
@@ -105,11 +133,6 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 							} else {
 								that.log("Unable to determine if update was successful.");
 								err = "Unknown Issue Ecountered";
-							}
-							if (callback) {
-								if (!err) callback();
-								else callback(err);
-								callback = null;
 							}
 						}, 800, 150, sProperty);
 				}


### PR DESCRIPTION
Modified to allow sProperty and sTarget to be an array for setting several things at the same time on a device.

Moved call back to allow the plugin to verify the command is possible and the light is connected and then report back to Siri. (#14, #21, #23, #26)
Fixed color change lights in the case of Phillips Hue. It is likely that this fixed other color light too, but I was only able to test with that one brand. (#18)