### PR TITLE
Fix for Node > 5.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
 		"homebridge": ">=0.2.5"
 	},
 	"dependencies": {
-		"wink-js": ">=0.1.0 <1.0.0"
+		"wink-js": "https://github.com/tekuonline/wink-js.git"
 	}
 }


### PR DESCRIPTION
Quick way to fix for node version greater than 4.5.
[wink-js](https://github.com/winfinit/wink-js) is using [config-file](https://github.com/jonschlinkert/config-file) which is somehow not compatible.
This will fix the issue for now. 