### PR TITLE
Brightness / Dimness settings fixes

### DIFF
--- a/accessories/light_bulbs.js
+++ b/accessories/light_bulbs.js
@@ -46,7 +46,8 @@ function WinkLightAccessory(platform, device) {
 			that.updateWinkProperty(callback, "powered", value);
 		});
 
-	if (that.device.desired_state.brightness !== undefined)
+	//Check if there is a node for brightness, if so add the characteristic
+	if (that.device.last_reading.brightness !== undefined)
 		this
 			.getService(Service.Lightbulb)
 			.getCharacteristic(Characteristic.Brightness)
@@ -59,7 +60,7 @@ function WinkLightAccessory(platform, device) {
 				that.updateWinkProperty(callback, "brightness", that.brightness);
 			});
 
-	if (that.device.desired_state.hue !== undefined)
+	if (that.device.last_reading.hue !== undefined)
 		this
 			.getService(Service.Lightbulb)
 			.getCharacteristic(Characteristic.Hue)
@@ -73,7 +74,7 @@ function WinkLightAccessory(platform, device) {
 											[that.hue, that.saturation, that.brightness, 'hsb']);				
 			});
 
-	if (that.device.desired_state.saturation !== undefined)
+	if (that.device.last_reading.saturation !== undefined)
 		this
 			.getService(Service.Lightbulb)
 			.getCharacteristic(Characteristic.Saturation)

--- a/lib/wink-accessory.js
+++ b/lib/wink-accessory.js
@@ -68,8 +68,11 @@ var refreshUntil = function (maxTimes, predicate, callback, interval, incrementI
 
 var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback) {
 	this.log("Changing target property '" + sProperty + "' of the " + this.device.device_group + " called " + this.device.name + " to " + sTarget);
+	this.log("Debug Logs Follow...");
+
 	if (this.device.desired_state == undefined) {
 		callback(Error("Unsupported"));
+		this.log("Desired State Undefined");
 		return;
 	}
 
@@ -77,16 +80,21 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 		for (var i = 0; i < sProperty.length; i++) {
 			if (this.device.desired_state[sProperty[i]] == undefined) {
 				callback(Error("Unsupported"));
+				this.log("Desired State Array Undefined");
 				return;
 			}
 		}
-	} else if (this.device.desired_state[sProperty] == undefined) {
-		callback(Error("Unsupported"));
-		return;
 	}
+
+	/* else if (this.device.desired_state[sProperty] == undefined) {
+		callback(Error("Unsupported"));
+		this.log("Desired State Array of 1 Undefined");
+		return;
+	} */
 
 	if (!this.device.last_reading.connection) {
 		callback(Error("Unconnected"));
+		this.log("Unconnected");
 		return;
 	}
 
@@ -101,6 +109,9 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 	} else {
 		data.desired_state[sProperty] = sTarget;
 	}
+
+	this.log("Reading Data: " + JSON.stringify(this.device));
+	this.log("Request Data: " + JSON.stringify(data));
 
 	var that = this;
 	var update = function (retry) {

--- a/lib/wink-accessory.js
+++ b/lib/wink-accessory.js
@@ -68,7 +68,6 @@ var refreshUntil = function (maxTimes, predicate, callback, interval, incrementI
 
 var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback) {
 	this.log("Changing target property '" + sProperty + "' of the " + this.device.device_group + " called " + this.device.name + " to " + sTarget);
-	this.log("Debug Logs Follow...");
 
 	if (this.device.desired_state == undefined) {
 		callback(Error("Unsupported"));
@@ -76,9 +75,10 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 		return;
 	}
 
+	//Check if there is an attribute in last_reading, if so, then we can apply desired_state
 	if (sProperty instanceof Array) {
 		for (var i = 0; i < sProperty.length; i++) {
-			if (this.device.desired_state[sProperty[i]] == undefined) {
+			if (this.device.last_reading[sProperty[i]] == undefined) {
 				callback(Error("Unsupported"));
 				this.log("Desired State Array Undefined");
 				return;
@@ -86,11 +86,11 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 		}
 	}
 
-	/* else if (this.device.desired_state[sProperty] == undefined) {
+	else if (this.device.last_reading[sProperty] == undefined) {
 		callback(Error("Unsupported"));
 		this.log("Desired State Array of 1 Undefined");
 		return;
-	} */
+	}
 
 	if (!this.device.last_reading.connection) {
 		callback(Error("Unconnected"));
@@ -110,9 +110,6 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 		data.desired_state[sProperty] = sTarget;
 	}
 
-	this.log("Reading Data: " + JSON.stringify(this.device));
-	this.log("Request Data: " + JSON.stringify(data));
-
 	var that = this;
 	var update = function (retry) {
 		that.control.update(data,
@@ -125,12 +122,13 @@ var updateWinkProperty = function (callback, sProperty, sTarget, bIgnoreFeedback
 				if (!err) {
 					that.refreshUntil(8,
 						function (sProperty) {
+								//Check if desired_state is cleared, if so then its applied, thus completed is true
 								if (sProperty instanceof Array) {
 									for (var i = 0; i < sProperty.length; i++) {
-										return ((that.device.last_reading[sProperty[i]] == that.device.desired_state[sProperty[i]]) || bIgnoreFeedback);
+										return ((that.device.desired_state[sProperty[i]] == undefined) || bIgnoreFeedback);
 									}
 								} else {
-									return ((that.device.last_reading[sProperty] == that.device.desired_state[sProperty]) || bIgnoreFeedback);
+									return ((that.device.desired_state[sProperty] == undefined) || bIgnoreFeedback);
 								}
 							
 						},


### PR DESCRIPTION
It seems that via wink-js we are not receiving the expected "desired_state", except for when it's been applied (see https://github.com/winfinit/wink-js/issues/12).  Thus, any checks for this will error out incorrectly.  While I can see this node typically populated if I query the API directly (eg via Postman), I don't see it returning data via wink-js.  I would say the problem is there except that in the Wink documentation for the API it specifically mentions this should be expected "http://docs.winkapiv2.apiary.io/#reference/device/desired-state-and-last-reading/retrieve-all-devices-of-user": "When the device acknowledges that the state has been applied, the server will clear the field from desired_state."  

Granted, that is the v2 documentation, and the v1 API specifically states that desired_state will describe writeable states, I suspect Wink has perhaps deprecated that behaviour.

As a result, the checks in accessories/light_bulbs.js result in no brightness characters being set (see https://github.com/KraigM/homebridge-wink/issues/61); However, if we check last_reading, it does get set correctly.  I tried this with numerous bulbs and switches (Lutron switch, Ecosmart A19 Bulb, Par20 Pot lights).

Also, due to the same concern with desired_state, when we're checking for whether to retry or not (in lib/wink_accessory.js), based on the behaviour I've been observing and the updated Wink documentation, it seems we should be checking for the absence of desired_state properties, since they get cleared once applied.  Otherwise, desired_state.powered (for example) will never equal last_reading.powered... which was the behaviour we observed.

Once I applied the changes in this optional patch, the behaviour seemed much more consistent with how it likely behaved previously.