### PR TITLE
Fix Siri control of locks

### DIFF
--- a/accessories/locks.js
+++ b/accessories/locks.js
@@ -66,6 +66,12 @@ function WinkLockAccessory(platform, device) {
 			}
 		})
 		.on('set', function (value, callback) {
+			if (value === false) {
+				value = Characteristic.LockTargetState.UNSECURED;
+			} else if (value === true) {
+				value = Characteristic.LockTargetState.SECURED;
+			}
+
 			switch (value) {
 				case Characteristic.LockTargetState.SECURED:
 					that.updateWinkProperty(callback, "locked", true);


### PR DESCRIPTION
It appears that on or around iOS 10.2 Siri began set boolean values for locking/unlocking where previously these had been integers. This workaround was used successfully in a fork of the smarthings plugin.